### PR TITLE
prevent client from hanging at end of tests

### DIFF
--- a/backend/empty.php
+++ b/backend/empty.php
@@ -1,4 +1,5 @@
 <?php
+set_time_limit (15); // prevent PHP from leaving sockets open with client
 header( "HTTP/1.1 200 OK" );
 if(isset($_GET["cors"])){
     header('Access-Control-Allow-Origin: *');


### PR DESCRIPTION
The client can appear to hang at the end of the tests and the PHP server can hold open the uploading connections longer than desired. This condition will usually happen on poor connections, it does not happen on good high bandwidth low latency connections.