### PR TITLE
HTTP Proxy support

### DIFF
--- a/backend/getIP.php
+++ b/backend/getIP.php
@@ -79,11 +79,15 @@ function getIpInfoTokenString(){
 	if(empty($IPINFO_APIKEY)) return "";
 	return "?token=".$IPINFO_APIKEY;
 }
+$httpproxyFile="getIP_ipInfo_httpproxy.php";
+if (!file_exists($httpproxyFile)) return "";
+require $httpproxyFile;
+if (empty($IPINFO_PROXYADDRESS)) $IPINFO_HTTPPROXY = $NULL;
 if (isset($_GET["isp"])) {
     $isp = "";
 	$rawIspInfo=null;
     try {
-        $json = file_get_contents("https://ipinfo.io/" . $ip . "/json".getIpInfoTokenString());
+        $json = file_get_contents("https://ipinfo.io/" . $ip . "/json".getIpInfoTokenString(), False, $IPINFO_HTTPPROXY););
         $details = json_decode($json, true);
 		$rawIspInfo=$details;
         if (array_key_exists("org", $details)){
@@ -107,7 +111,7 @@ if (isset($_GET["isp"])) {
 				if(file_exists($locFile)){
 					require $locFile;
 				}else{
-					$json = file_get_contents("https://ipinfo.io/json".getIpInfoTokenString());
+					$json = file_get_contents("https://ipinfo.io/json".getIpInfoTokenString(), False, $IPINFO_HTTPPROXY););
 					$details = json_decode($json, true);
 					if (array_key_exists("loc", $details)){
 						$serverLoc = $details["loc"];

--- a/backend/getIP_ipinfo_httpproxy.php
+++ b/backend/getIP_ipinfo_httpproxy.php
@@ -1,0 +1,16 @@
+<?php
+$IPINFO_PROXYADDRESS=""; // leave proxy address blank for direct
+$IPINFO_PROXYPORT="800";
+
+$streamContext = array(
+    "ssl"=>array(
+        "verify_peer"=>false,
+        "verify_peer_name"=>false,
+    ),
+    'http' => array(
+        'proxy'           => 'tcp://'.$IPINFO_PROXYADDRESS.':'.$IPINFO_PROXYPORT,
+        'request_fulluri' => true,
+    ),
+);
+$IPINFO_HTTPPROXY= stream_context_create($streamContext);
+?>


### PR DESCRIPTION
I logged a issue https://github.com/librespeed/speedtest/issues/289 as https://ipinfo.io/ request would time out, This was causing the speedtest to hang for 60 seconds before it would start. HTTP/HTTPS is blocked in my environments and we are forced to make web requests via http proxy. Setting the system proxy fails to make any difference on my web servers. 

As such, I have created proxy support in my fork.

Tested with proxy address set and blank, OK. 

PS, I'm a sys admin, not a dev.