### PR TITLE
Update the unit symbols

### DIFF
--- a/doc.md
+++ b/doc.md
@@ -282,11 +282,11 @@ The `onupdate` event handler will be called periodically by the test with data c
     * `5` = Test aborted
 * __dlStatus__: either
     * Empty string (not started or aborted)
-    * Download speed in Megabit/s as a number with 2 decimals
+    * Download speed in Mbit/s (or Mibit/s) as a number with 2 decimals
     * The string "Fail" (test failed)
 * __ulStatus__: either
     * Empty string (not started or aborted)
-    * Upload speed in Megabit/s as a number with 2 decimals
+    * Upload speed in Mbit/s (or Mibit/s) as a number with 2 decimals
     * The string "Fail" (test failed)
 * __pingStatus__: either
     * Empty string (not started or aborted)
@@ -406,7 +406,7 @@ __Advanced parameters:__ (Seriously, don't change these unless you know what you
 * __ping_allowPerformanceApi__: toggles use of Performance API to improve accuracy of Ping/Jitter test on browsers that support it.
 	* Default: `true`
 	* Default override: `false` on Firefox because its performance API implementation is inaccurate
-* __useMebibits__: use mebibits/s instead of megabits/s for the speeds
+* __useMebibits__: use mebibits per second (Mibit/s) instead of megabits per second (Mbit/s) for the speeds
 	* Default: `false`
 * __overheadCompensationFactor__: compensation for HTTP and network overhead. Default value assumes typical MTUs used over the Internet. You might want to change this if you're using this in your internal network with different MTUs, or if you're using IPv6 instead of IPv4.
     * Default: `1.06` probably a decent estimate for all overhead. This was measured empirically by comparing the measured speed and the speed reported by my the network adapter.
@@ -507,8 +507,8 @@ You can think of this as a finite state machine. These are the states (use getSt
     While in state 1, you can only add test points, you cannot change the test settings. When you're done, use selectServer(callback) to select the test point with the lowest ping. This is asynchronous, when it's done, it will call your callback function and move to state 2. Calling setSelectedServer(server) will manually select a server and move to state 2.
 * __2__: test point selected, ready to start the test. Use `start()` to begin, this will move to state 3
 * __3__: test running. Here, your `onupdate` event calback will be called periodically, with data coming from the worker about speed and progress. A data object will be passed to your `onupdate` function, with the following items:
-        - `dlStatus`: download speed in mbps
-        - `ulStatus`: upload speed in mbps
+        - `dlStatus`: download speed in Mbit/s
+        - `ulStatus`: upload speed in Mbit/s
         - `pingStatus`: ping in ms
         - `jitterStatus`: jitter in ms
         - `dlProgress`: progress of the download test as a float 0-1

--- a/example-multipleServers-full.html
+++ b/example-multipleServers-full.html
@@ -424,13 +424,13 @@ function initUI(){
 				<div class="testName">Download</div>
 				<canvas id="dlMeter" class="meter"></canvas>
 				<div id="dlText" class="meterText"></div>
-				<div class="unit">Mbps</div>
+				<div class="unit">Mbit/s</div>
 			</div>
 			<div class="testArea">
 				<div class="testName">Upload</div>
 				<canvas id="ulMeter" class="meter"></canvas>
 				<div id="ulText" class="meterText"></div>
-				<div class="unit">Mbps</div>
+				<div class="unit">Mbit/s</div>
 			</div>
 		</div>
 		<div id="ipArea">

--- a/example-multipleServers-pretty.html
+++ b/example-multipleServers-pretty.html
@@ -212,12 +212,12 @@ function I(id){return document.getElementById(id);}
 		<div class="testArea">
 			<div class="testName">Download</div>
 			<div id="dlText" class="meterText"></div>
-			<div class="unit">Mbps</div>
+			<div class="unit">Mbit/s</div>
 		</div>
 		<div class="testArea">
 			<div class="testName">Upload</div>
 			<div id="ulText" class="meterText"></div>
-			<div class="unit">Mbps</div>
+			<div class="unit">Mbit/s</div>
 		</div>
 	</div>
 	<div class="testGroup">

--- a/example-singleServer-customSettings.html
+++ b/example-singleServer-customSettings.html
@@ -157,12 +157,12 @@ function I(id){return document.getElementById(id);}
 		<div class="testArea">
 			<div class="testName">Download</div>
 			<div id="dlText" class="meterText"></div>
-			<div class="unit">Mbps</div>
+			<div class="unit">Mbit/s</div>
 		</div>
 		<div class="testArea">
 			<div class="testName">Upload</div>
 			<div id="ulText" class="meterText"></div>
-			<div class="unit">Mbps</div>
+			<div class="unit">Mbit/s</div>
 		</div>
 	</div>
 </div>

--- a/example-singleServer-full.html
+++ b/example-singleServer-full.html
@@ -298,13 +298,13 @@ function initUI(){
 				<div class="testName">Download</div>
 				<canvas id="dlMeter" class="meter"></canvas>
 				<div id="dlText" class="meterText"></div>
-				<div class="unit">Mbps</div>
+				<div class="unit">Mbit/s</div>
 			</div>
 			<div class="testArea">
 				<div class="testName">Upload</div>
 				<canvas id="ulMeter" class="meter"></canvas>
 				<div id="ulText" class="meterText"></div>
-				<div class="unit">Mbps</div>
+				<div class="unit">Mbit/s</div>
 			</div>
 		</div>
 		<div id="ipArea">

--- a/example-singleServer-gauges.html
+++ b/example-singleServer-gauges.html
@@ -242,13 +242,13 @@ function initUI(){
 				<div class="testName">Download</div>
 				<canvas id="dlMeter" class="meter"></canvas>
 				<div id="dlText" class="meterText"></div>
-				<div class="unit">Mbps</div>
+				<div class="unit">Mbit/s</div>
 			</div>
 			<div class="testArea">
 				<div class="testName">Upload</div>
 				<canvas id="ulMeter" class="meter"></canvas>
 				<div id="ulText" class="meterText"></div>
-				<div class="unit">Mbps</div>
+				<div class="unit">Mbit/s</div>
 			</div>
 		</div>
 		<div id="ipArea">

--- a/example-singleServer-pretty.html
+++ b/example-singleServer-pretty.html
@@ -160,12 +160,12 @@ function I(id){return document.getElementById(id);}
 		<div class="testArea">
 			<div class="testName">Download</div>
 			<div id="dlText" class="meterText"></div>
-			<div class="unit">Mbps</div>
+			<div class="unit">Mbit/s</div>
 		</div>
 		<div class="testArea">
 			<div class="testName">Upload</div>
 			<div id="ulText" class="meterText"></div>
-			<div class="unit">Mbps</div>
+			<div class="unit">Mbit/s</div>
 		</div>
 	</div>
 	<div class="testGroup">

--- a/example-singleServer-progressBar.html
+++ b/example-singleServer-progressBar.html
@@ -180,12 +180,12 @@ function I(id){return document.getElementById(id);}
 		<div class="testArea">
 			<div class="testName">Download</div>
 			<div id="dlText" class="meterText"></div>
-			<div class="unit">Mbps</div>
+			<div class="unit">Mbit/s</div>
 		</div>
 		<div class="testArea">
 			<div class="testName">Upload</div>
 			<div id="ulText" class="meterText"></div>
-			<div class="unit">Mbps</div>
+			<div class="unit">Mbit/s</div>
 		</div>
 	</div>
 	<div class="testGroup">

--- a/results/index.php
+++ b/results/index.php
@@ -162,7 +162,7 @@ function drawImage($speedtest)
     $POSITION_Y_WATERMARK = 223 * $SCALE;
 
     // configure labels
-    $MBPS_TEXT = 'Mbps';
+    $MBPS_TEXT = 'Mbit/s';
     $MS_TEXT = 'ms';
     $PING_TEXT = 'Ping';
     $JIT_TEXT = 'Jitter';

--- a/speedtest.js
+++ b/speedtest.js
@@ -28,8 +28,8 @@
         While in state 1, you can only add test points, you cannot change the test settings. When you're done, use selectServer(callback) to select the test point with the lowest ping. This is asynchronous, when it's done, it will call your callback function and move to state 2. Calling setSelectedServer(server) will manually select a server and move to state 2.
     - 2: test point selected, ready to start the test. Use start() to begin, this will move to state 3
     - 3: test running. Here, your onupdate event calback will be called periodically, with data coming from the worker about speed and progress. A data object will be passed to your onupdate function, with the following items:
-            - dlStatus: download speed in mbps
-            - ulStatus: upload speed in mbps
+            - dlStatus: download speed in Mbit/s
+            - ulStatus: upload speed in Mbit/s
             - pingStatus: ping in ms
             - jitterStatus: jitter in ms
             - dlProgress: progress of the download test as a float 0-1


### PR DESCRIPTION
The ad-hoc abbreviation "Mbps" for "megabits per second" was
used originally to refer to the unit since an official symbol did
not exist at the time. An official symbol now exists and the
abbreviation has been deprecated, so this commit updates these to
the official symbol.