### PR TITLE
added external db support for docker frontend & standalone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,18 @@
 FROM php:7.2-apache
 
-# Install extensions
+# Install extensions, including PHP PDO support for Postgres
+# NOTE: MYSQL SUPPORT NOT INCLUDED
 RUN apt-get update && apt-get install -y \
         libfreetype6-dev \
         libjpeg62-turbo-dev \
         libpng-dev \
+        libpq-dev \
     && docker-php-ext-install -j$(nproc) iconv \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-install -j$(nproc) gd
+    && docker-php-ext-install -j$(nproc) gd \
+    && docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql \
+    && docker-php-ext-install -j$(nproc) pdo_pgsql pgsql
+    
 
 # Prepare files and folders
 

--- a/doc.md
+++ b/doc.md
@@ -24,6 +24,11 @@ Here's a list of additional environment variables available in this mode:
 * __`IPINFO_APIKEY`__: API key for ipinfo.io. Optional, but required if you expect to serve a large number of tests
 * __`DISABLE_IPINFO`__: If set to true, ISP info and distance will not be fetched from ipinfo.io. Default: value: `false`
 * __`DISTANCE`__: When `DISABLE_IPINFO` is set to false, this specifies how the distance from the server is measured. Can be either `km` for kilometers, `mi` for miles, or an empty string to disable distance measurement. Default value: `km`
+* __`DB_TYPE`__: To use your own database, specify `postgresql` or `mysql` here. Any other value will default to using a local sqlite database.
+* __`DB_HOSTNAME`__: URL of database server
+* __`DB_DATABASENAME`__: name of database
+* __`DB_USERNAME`__: username for database access
+* __`DB_PASSWORD`__: password for for database access
 
 If telemetry is enabled, a stats page will be available at `http://your.server/results/stats.php`, but a password must be specified.
 
@@ -202,6 +207,11 @@ Here's a list of additional environment variables available in this mode:
 * __`EMAIL`__: Email address for GDPR requests. Must be specified when telemetry is enabled.
 * __`DISABLE_IPINFO`__: If set to true, ISP info and distance will not be fetched from ipinfo.io. Default: value: `false`
 * __`DISTANCE`__: When `DISABLE_IPINFO` is set to false, this specifies how the distance from the server is measured. Can be either `km` for kilometers, `mi` for miles, or an empty string to disable distance measurement. Default value: `km`
+* __`DB_TYPE`__: To use your own database, specify `postgresql` or `mysql` here. Any other value will default to using a local sqlite database.
+* __`DB_HOSTNAME`__: URL of database server
+* __`DB_DATABASENAME`__: name of database
+* __`DB_USERNAME`__: username for database access
+* __`DB_PASSWORD`__: password for for database access
 
 ###### Example
 This command starts LibreSpeed in frontend mode, with a given `servers.json` file, and with telemetry, ID obfuscation, and a stats password:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -35,9 +35,24 @@ fi
 if [[ "$TELEMETRY" == "true" && ( "$MODE" == "frontend" || "$MODE" == "standalone" ) ]]; then
   cp -r /speedtest/results /var/www/html/results
 
-  sed -i s/\$db_type=\".*\"/\$db_type=\"sqlite\"\;/g /var/www/html/results/telemetry_settings.php
-  sed -i s/\$Sqlite_db_file\ =\ \".*\"/\$Sqlite_db_file=\"\\\/database\\\/db.sql\"/g /var/www/html/results/telemetry_settings.php
   sed -i s/\$stats_password=\".*\"/\$stats_password=\"$PASSWORD\"/g /var/www/html/results/telemetry_settings.php
+  
+  if [[ "$DB_TYPE" == "postgresql" ]]; then
+	  sed -i s/\$db_type=\".*\"/\$db_type=\"postgresql\"\;/g /var/www/html/results/telemetry_settings.php
+	  sed -i s/\$PostgreSql_hostname=\".*\"/\$PostgreSql_hostname=\"$DB_HOSTNAME\"/g /var/www/html/results/telemetry_settings.php
+	  sed -i s/\$PostgreSql_databasename=\".*\"/\$PostgreSql_databasename=\"$DB_DATABASENAME\"/g /var/www/html/results/telemetry_settings.php
+	  sed -i s/\$PostgreSql_username=\".*\"/\$PostgreSql_username=\"$DB_USERNAME\"/g /var/www/html/results/telemetry_settings.php
+	  sed -i s/\$PostgreSql_password=\".*\"/\$PostgreSql_password=\"$DB_PASSWORD\"/g /var/www/html/results/telemetry_settings.php
+  elif [[ "$DB_TYPE" == "mysql" ]]; then
+	  sed -i s/\$db_type=\".*\"/\$db_type=\"mysql\"\;/g /var/www/html/results/telemetry_settings.php
+	  sed -i s/\$MySql_hostname=\".*\"/\$MySql_hostname=\"$DB_HOSTNAME\"/g /var/www/html/results/telemetry_settings.php
+	  sed -i s/\$MySql_databasename=\".*\"/\$MySql_databasename=\"$DB_DATABASENAME\"/g /var/www/html/results/telemetry_settings.php
+	  sed -i s/\$MySql_username=\".*\"/\$MySql_username=\"$DB_USERNAME\"/g /var/www/html/results/telemetry_settings.php
+	  sed -i s/\$MySql_password=\".*\"/\$MySql_password=\"$DB_PASSWORD\"/g /var/www/html/results/telemetry_settings.php
+  else
+	  sed -i s/\$db_type=\".*\"/\$db_type=\"sqlite\"\;/g /var/www/html/results/telemetry_settings.php
+	  sed -i s/\$Sqlite_db_file\ =\ \".*\"/\$Sqlite_db_file=\"\\\/database\\\/db.sql\"/g /var/www/html/results/telemetry_settings.php
+  fi
 
   if [ "$ENABLE_ID_OBFUSCATION" == "true" ]; then
     sed -i s/\$enable_id_obfuscation=.*\;/\$enable_id_obfuscation=true\;/g /var/www/html/results/telemetry_settings.php


### PR DESCRIPTION
- updates to doc.md specify new env's for use with an external database
- Dockerfile update includes support for postgres PDO's in PHP (mysql PDO support NOT added)
- Tested as standalone with postgres only. mysql NOT tested but should follow same pattern (also note no mysql support added in Dockerfile)
- Also note: recent update to master added support for alternate port with mysql which has NOT been merged to the docker branch (PR #330)