### PR TITLE
Fix check for X-Real-IP header when trying to find the correct client IP

### DIFF
--- a/backend/getIP.php
+++ b/backend/getIP.php
@@ -18,8 +18,8 @@ function getClientIp()
 {
     if (!empty($_SERVER['HTTP_CLIENT_IP'])) {
         $ip = $_SERVER['HTTP_CLIENT_IP'];
-    } elseif (!empty($_SERVER['X-Real-IP'])) {
-        $ip = $_SERVER['X-Real-IP'];
+    } elseif (!empty($_SERVER['HTTP_X_REAL_IP'])) {
+        $ip = $_SERVER['HTTP_X_REAL_IP'];
     } elseif (!empty($_SERVER['HTTP_X_FORWARDED_FOR'])) {
         $ip = $_SERVER['HTTP_X_FORWARDED_FOR'];
         $ip = preg_replace('/,.*/', '', $ip); # hosts are comma-separated, client is first


### PR DESCRIPTION
Fixes #306 

I don't have some proxy or something at hand which would set this header, but I tested the change with curl.

Before this change:

```
$ curl http://my-deployment-of-librespeed/backend/getIP.php -H 'X-Real-IP: foobar'
{"processedString":"<MY_IP>","rawIspInfo":""}
```

After this change:

```
$ curl http://my-deployment-of-librespeed/backend/getIP.php -H 'X-Real-IP: foobar'
{"processedString":"foobar","rawIspInfo":""}
```