### PR TITLE
make the clickable area around the link to the privacy message a bit …

### DIFF
--- a/example-multipleServers-full.html
+++ b/example-multipleServers-full.html
@@ -352,7 +352,15 @@ function initUI(){
         text-align:center;
         font-size:0.8em;
         color:#808080;
+        padding: 0 3em;
 	}
+    div.closePrivacyPolicy {
+        width: 100%;
+        text-align: center;
+    }
+    div.closePrivacyPolicy a.privacy {
+        padding: 1em 3em;
+    }
 	@media all and (max-width:40em){
 		body{
 			font-size:0.8em;
@@ -473,7 +481,10 @@ function initUI(){
         Contact this email address for all deletion requests: <a href="mailto:PUT@YOUR_EMAIL.HERE">TO BE FILLED BY DEVELOPER</a>.
     </p>
     <br/><br/>
-    <a class="privacy" href="#" onclick="I('privacyPolicy').style.display='none'">Close</a><br/>
+    <div class="closePrivacyPolicy">
+        <a class="privacy" href="#" onclick="I('privacyPolicy').style.display='none'">Close</a>
+    </div>
+    <br/>
 </div>
 </body>
 </html>

--- a/example-singleServer-full.html
+++ b/example-singleServer-full.html
@@ -258,7 +258,15 @@ function initUI(){
         text-align:center;
         font-size:0.8em;
         color:#808080;
-	}
+        padding: 0 3em;
+    }
+    div.closePrivacyPolicy {
+        width: 100%;
+        text-align: center;
+    }
+    div.closePrivacyPolicy a.privacy {
+        padding: 1em 3em;
+    }
 	@media all and (max-width:40em){
 		body{
 			font-size:0.8em;
@@ -347,7 +355,10 @@ function initUI(){
         Contact this email address for all deletion requests: <a href="mailto:PUT@YOUR_EMAIL.HERE">TO BE FILLED BY DEVELOPER</a>.
     </p>
     <br/><br/>
-    <a class="privacy" href="#" onclick="I('privacyPolicy').style.display='none'">Close</a><br/>
+    <div class="closePrivacyPolicy">
+        <a class="privacy" href="#" onclick="I('privacyPolicy').style.display='none'">Close</a>
+    </div>
+    <br/>
 </div>
 <script type="text/javascript">setTimeout(function(){initUI()},100);</script>
 </body>


### PR DESCRIPTION
…bigger again so that it's easier to click on mobile devices

Followup to #364 

As stated in https://github.com/librespeed/speedtest/pull/364#issuecomment-706576947 the link shouldn't be too small, to make it easy to click on it even on mobile devices. So I made the clickable area roughly the size of the 'start' button.

For the button to open the privacy policy it's basically as it was before #364 but just not over the complete width of the page, so just clickable left and right of the link but not above or below (to prevent accidental clicking when the user wants to click on the start button):
![open_button](https://user-images.githubusercontent.com/16883833/95661403-56a5b180-0b2f-11eb-8182-93c2992b9ec1.png)

For the button to close the privacy policy I added some padding roughly the size of the 'start' button all around ('start' button has 3em of height, so I added 1em padding to top and bottom of the link):
![close_button](https://user-images.githubusercontent.com/16883833/95661405-586f7500-0b2f-11eb-9635-8ff518897c7e.png)
