### PR TITLE
Added #476: Open "Source Code" link in a new tab 

### DIFF
--- a/docker/frontend.php
+++ b/docker/frontend.php
@@ -428,7 +428,7 @@ function initUI(){
 			<img src="" id="resultsImg" />
 		</div>
 	</div>
-	<a href="https://github.com/librespeed/speedtest">Source code</a>
+	<a href="https://github.com/librespeed/speedtest" target="_blank" rel="noopener noreferrer">Source code</a>
 </div>
 <div id="privacyPolicy" style="display:none">
     <h2>Privacy Policy</h2>

--- a/docker/standalone.php
+++ b/docker/standalone.php
@@ -320,7 +320,7 @@ function initUI(){
 			<img src="" id="resultsImg" />
 		</div>
 	</div>
-	<a href="https://github.com/librespeed/speedtest">Source code</a>
+	<a href="https://github.com/librespeed/speedtest" target="_blank" rel="noopener noreferrer">Source code</a>
 </div>
 <div id="privacyPolicy" style="display:none">
     <h2>Privacy Policy</h2>

--- a/example-multipleServers-full.html
+++ b/example-multipleServers-full.html
@@ -443,7 +443,7 @@ function initUI(){
 			<img src="" id="resultsImg" />
 		</div>
 	</div>
-	<a href="https://github.com/librespeed/speedtest">Source code</a>
+	<a href="https://github.com/librespeed/speedtest" target="_blank" rel="noopener noreferrer">Source code</a>
 </div>
 <div id="privacyPolicy" style="display:none">
     <h2>Privacy Policy</h2>

--- a/example-multipleServers-pretty.html
+++ b/example-multipleServers-pretty.html
@@ -236,7 +236,7 @@ function I(id){return document.getElementById(id);}
 		IP Address: <span id="ip"></span>
 	</div>
 </div>
-<a href="https://github.com/librespeed/speedtest">Source code</a>
+<a href="https://github.com/librespeed/speedtest" target="_blank" rel="noopener noreferrer">Source code</a>
 <script type="text/javascript">
     initUI();
     loadServers();

--- a/example-singleServer-basic.html
+++ b/example-singleServer-basic.html
@@ -32,7 +32,7 @@
         s.start(); // start the speedtest with default settings
     </script>
 
-	<a href="https://github.com/librespeed/speedtest">Source code</a>
+	<a href="https://github.com/librespeed/speedtest" target="_blank" rel="noopener noreferrer">Source code</a>
 
 </body>
 </html>

--- a/example-singleServer-chart.html
+++ b/example-singleServer-chart.html
@@ -251,6 +251,6 @@
         <a href="javascript:abortTest()" id="abortBtn">Abort</a>
     </div>
     <a href="javascript:runTest()" id="startBtn">Run speedtest</a>
-    <br/><br/> Charts by <a href="http://www.chartjs.org/">Chart.js</a><br/><br/><a href="https://github.com/librespeed/speedtest">Source code</a>
+    <br/><br/> Charts by <a href="http://www.chartjs.org/" target="_blank" rel="noopener noreferrer">Chart.js</a><br/><br/><a href="https://github.com/librespeed/speedtest" target="_blank" rel="noopener noreferrer">Source code</a>
 </body>
 </html>

--- a/example-singleServer-customSettings.html
+++ b/example-singleServer-customSettings.html
@@ -166,7 +166,7 @@ function I(id){return document.getElementById(id);}
 		</div>
 	</div>
 </div>
-<a href="https://github.com/librespeed/speedtest">Source code</a>
+<a href="https://github.com/librespeed/speedtest" target="_blank" rel="noopener noreferrer">Source code</a>
 <script type="text/javascript">
     initUI();
 </script>

--- a/example-singleServer-full.html
+++ b/example-singleServer-full.html
@@ -317,7 +317,7 @@ function initUI(){
 			<img src="" id="resultsImg" />
 		</div>
 	</div>
-	<a href="https://github.com/librespeed/speedtest">Source code</a>
+	<a href="https://github.com/librespeed/speedtest" target="_blank" rel="noopener noreferrer">Source code</a>
 </div>
 <div id="privacyPolicy" style="display:none">
     <h2>Privacy Policy</h2>

--- a/example-singleServer-gauges.html
+++ b/example-singleServer-gauges.html
@@ -255,7 +255,7 @@ function initUI(){
 			<span id="ip"></span>
 		</div>
 	</div>
-	<a href="https://github.com/librespeed/speedtest">Source code</a>
+	<a href="https://github.com/librespeed/speedtest" target="_blank" rel="noopener noreferrer">Source code</a>
 </div>
 <script type="text/javascript">setTimeout(function(){initUI()},100);</script>
 </body>

--- a/example-singleServer-pretty.html
+++ b/example-singleServer-pretty.html
@@ -184,7 +184,7 @@ function I(id){return document.getElementById(id);}
 		IP Address: <span id="ip"></span>
 	</div>
 </div>
-<a href="https://github.com/librespeed/speedtest">Source code</a>
+<a href="https://github.com/librespeed/speedtest" target="_blank" rel="noopener noreferrer">Source code</a>
 <script type="text/javascript">
     initUI();
 </script>

--- a/example-singleServer-progressBar.html
+++ b/example-singleServer-progressBar.html
@@ -204,7 +204,7 @@ function I(id){return document.getElementById(id);}
 		IP Address: <span id="ip"></span>
 	</div>
 </div>
-<a href="https://github.com/librespeed/speedtest">Source code</a>
+<a href="https://github.com/librespeed/speedtest" target="_blank" rel="noopener noreferrer">Source code</a>
 <script type="text/javascript">
     initUI();
 </script>


### PR DESCRIPTION
This just makes the links to the source code and Chart.js open in a new
tab. The `rel="noopener noreferrer"` has been added to prevent security
issues in older browsers. This is just an ease of use change that
doesn't affect any of the core speedtest functionality in any way.

Closes #476 
