### PR TITLE
Set content-type before sending image data for a valid response

### DIFF
--- a/results/index.php
+++ b/results/index.php
@@ -212,7 +212,6 @@ function drawImage($speedtest)
     imagefttext($im, $FONT_WATERMARK_SIZE, 0, $POSITION_X_WATERMARK, $POSITION_Y_WATERMARK, $TEXT_COLOR_WATERMARK, $FONT_WATERMARK, $WATERMARK_TEXT);
 
     // send the image to the browser
-    header('Content-Type: image/png');
     imagepng($im);
 }
 
@@ -221,4 +220,5 @@ if (!is_array($speedtest)) {
     exit(1);
 }
 
+header('Content-Type: image/png');
 drawImage($speedtest);


### PR DESCRIPTION
Chromium displays a bad image icon instead of the generated png because the content-type is not set (returns text/html).
Setting the content type before generating the image resolves this issue.