### PR TITLE
Microsoft SQL Server support and Sanity Check page

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Works with mobile versions too.
 ## Server requirements
 * A reasonably fast web server with Apache 2 (nginx, IIS also supported)
 * PHP 5.4 (other backends also available)
-* MySQL database to store test results (optional, PostgreSQL and SQLite also supported)
+* MySQL database to store test results (optional, Microsoft SQL Server, PostgreSQL and SQLite also supported)
 * A fast! internet connection
 
 ## Installation videos

--- a/results/sanitycheck.php
+++ b/results/sanitycheck.php
@@ -1,0 +1,189 @@
+<?php
+require_once 'telemetry_settings.php';
+require_once 'telemetry_db.php';
+require_once '../backend/getIP_util.php';
+
+error_reporting(E_ALL);
+
+$pass="<span class='Pass'>Pass</span>";
+$failed="<span class='Failed'>failed</span>";
+$na="<span class='na'>N/A</span>";
+?>
+
+<html>
+<head>
+<title>Speed Test installation sanity check</title>
+<style>
+	table,th,td { border: 1px solid;}
+	.Pass   { color:green;}
+	.Failed { color:red;}
+	.na     { color:orange;}
+	.SectionHeading { font-style: italic;}
+</style>
+</head>
+<body>
+<table><tr><th>Item</th><th>Status</th><th>Comment</th></tr>
+<tr><td colspan="3" class='SectionHeading'>PHP extensions</td></tr>
+
+<tr><td>gd</td><td>
+<?php
+if(extension_loaded('gd')){
+	echo $pass;
+} else {
+	echo $failed;
+}
+?>
+</td><td>Used to render result images.</td></tr>
+
+<tr><td>openssl</td><td>
+<?php
+if(extension_loaded('openssl')){
+	echo $pass;
+} else {
+	echo $failed;
+}
+?>
+</td><td></td></tr>
+
+<tr><td>pdo_sqlsrv</td><td>
+<?php
+if(!isset($db_type) || $db_type != 'mssql'){
+	echo $na;
+}elseif(extension_loaded('pdo_sqlsrv')){
+	echo $pass;
+} else {
+	echo $failed;
+}
+?>
+</td><td>Only required if using MS SQL.</td></tr>
+
+<tr><td>pdo_mysql</td><td>
+<?php
+if(!isset($db_type) || $db_type != 'mysql'){
+	echo $na;
+}elseif(extension_loaded('pdo_mysql')){
+	echo $pass;
+} else {
+	echo $failed;
+}
+?>
+</td><td>Only required if using mysql.</td></tr>
+
+<tr><td>pdo_sqlite</td><td>
+<?php
+if(!isset($db_type) || $db_type != 'sqlite'){
+	echo $na;
+}elseif(extension_loaded('pdo_sqlite')){
+	echo $pass;
+} else {
+	echo $failed;
+}
+?>
+</td><td>Only required if using sqlite.</td></tr>
+
+
+<tr><td>pdo_pgsql</td><td>
+<?php
+if(!isset($db_type) || $db_type != 'postgresql'){
+	echo $na;
+}elseif(extension_loaded('pdo_pgsql')){
+	echo $pass;
+} else {
+	echo $failed;
+}
+?>
+</td><td>Only required if using sqlite.</td></tr>
+
+
+<tr><td colspan="3" class='SectionHeading'>Database check</td></tr>
+<td>Connecting to DB</td><td>
+<?php
+	$pdo = getPdo(true);
+	if (($pdo instanceof PDO)) {
+		echo $pass;
+		echo "</td><td></td>";
+	} else {
+		echo $failed;
+		echo "</td><td>". htmlspecialchars($pdo) . "</td>";
+	}
+?>
+</tr>
+
+<tr><td>Insert into DB</td><td>
+<?php
+	$ip = getClientIp();
+	$ispinfo="";
+	$extra='{"DBTest":"This is a simple test of the database.  No speed test was done."}';
+	$ua = $_SERVER['HTTP_USER_AGENT'];
+	$lang = '';
+	if (isset($_SERVER['HTTP_ACCEPT_LANGUAGE'])) {
+		$lang = $_SERVER['HTTP_ACCEPT_LANGUAGE'];
+	}
+
+	$dl=$ul=$ping=$jitter="";
+	$log="";
+
+	$insertResult = insertSpeedtestUser($ip, $ispinfo, $extra, $ua, $lang, $dl, $ul, $ping, $jitter, $log, true);
+	
+	if(($insertResult instanceof Exception)){
+		echo $failed;
+		echo "</td><td>";
+		echo htmlspecialchars($insertResult->getMessage()) . "</td>";
+	} else {
+		echo $pass;
+		echo "</td><td></td>";
+	}
+?>
+</tr>
+
+<tr><td>Read from DB</td><td>
+<?php
+	if(!($insertResult instanceof Exception)){
+		$QueryResult = getSpeedtestUserById($insertResult,true);
+		
+		if(($QueryResult instanceof Exception)){
+			echo $failed;
+			echo "</td><td>";
+			echo htmlspecialchars($insertResult->getMessage()) . "</td>";
+		} elseif(!is_array($QueryResult)) {
+			echo $failed;
+			echo "</td><td>Test result not retrieved from database.</td>";
+		} else {
+			echo $pass;
+			echo "</td><td></td>";
+		}
+	} else {
+		echo "</td><td>Insert failed so can't test reading inserted data</td>";
+	}
+?>
+</tr>
+
+</table>
+</body>
+</html>
+<?php
+/*
+$speedtests = getLatestSpeedtestUsers();
+print_r ($speedtests);
+
+
+echo '   ';
+print_r($pdo);
+if(!isset($pdo)){
+	echo 'got nothing';
+} 
+if($pdo == false){
+	echo 'got a false';
+}
+if (!($pdo instanceof PDO)) {
+    echo 'not a PDO';
+}
+if (($pdo instanceof PDO)) {
+    echo 'is PDO';
+}
+
+
+$speedtest = getSpeedtestUserById(1);
+print_r ($speedtest);
+*/
+?>

--- a/results/sanitycheck.php
+++ b/results/sanitycheck.php
@@ -96,7 +96,7 @@ if(!isset($db_type) || $db_type != 'postgresql'){
 
 
 <tr><td colspan="3" class='SectionHeading'>Database check</td></tr>
-<td>Connecting to DB</td><td>
+<tr><td>Connecting to DB</td><td>
 <?php
 	$pdo = getPdo(true);
 	if (($pdo instanceof PDO)) {

--- a/results/telemetry_mssql.sql
+++ b/results/telemetry_mssql.sql
@@ -1,0 +1,30 @@
+SET ANSI_NULLS ON
+GO
+
+SET QUOTED_IDENTIFIER ON
+GO
+
+CREATE TABLE [dbo].[speedtest_users](
+	[id] [bigint] IDENTITY(120,1) NOT NULL,
+	[timestamp] [datetime] NOT NULL,
+	[ip] [nvarchar](max) NOT NULL,
+	[ispinfo] [nvarchar](max) NULL,
+	[extra] [nvarchar](max) NULL,
+	[ua] [nvarchar](max) NOT NULL,
+	[lang] [nvarchar](max) NOT NULL,
+	[dl] [nvarchar](max) NULL,
+	[ul] [nvarchar](max) NULL,
+	[ping] [nvarchar](max) NULL,
+	[jitter] [nvarchar](max) NULL,
+	[log] [nvarchar](max) NULL,
+ CONSTRAINT [PK_speedtest_users] PRIMARY KEY CLUSTERED 
+(
+	[id] ASC
+)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
+) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
+GO
+
+ALTER TABLE [dbo].[speedtest_users] ADD  CONSTRAINT [DF_speedtest_users_timestamp]  DEFAULT (getdate()) FOR [timestamp]
+GO
+
+

--- a/results/telemetry_settings.php
+++ b/results/telemetry_settings.php
@@ -1,6 +1,6 @@
 <?php
 
-// Type of db: "mysql", "sqlite" or "postgresql"
+// Type of db: "mssql", "mysql", "sqlite" or "postgresql"
 $db_type = 'mysql';
 // Password to login to stats.php. Change this!!!
 $stats_password = 'PASSWORD';
@@ -11,6 +11,15 @@ $redact_ip_addresses = false;
 
 // Sqlite3 settings
 $Sqlite_db_file = '../../speedtest_telemetry.sql';
+
+// mssql settings
+$MsSql_server = 'DB_HOSTNAME';
+$MsSql_databasename = 'DB_NAME';
+$MsSql_WindowsAuthentication = true;   #true or false
+$MsSql_username = 'USERNAME';          #not used if MsSql_WindowsAuthentication is true
+$MsSql_password = 'PASSWORD';          #not used if MsSql_WindowsAuthentication is true
+$MsSql_TrustServerCertificate = true;  #true, false or comment out for driver default
+#Download driver from https://docs.microsoft.com/en-us/sql/connect/php/download-drivers-php-sql-server?view=sql-server-ver16
 
 // Mysql settings
 $MySql_username = 'USERNAME';


### PR DESCRIPTION
I have added support for using Microsoft SQL Server to host the speedtest database.  
To help with debugging DB connectivity issues, I also created a Sanity Check page which checks if required PHP extensions are installed, and that the website can connect to the database.