### PR TITLE
Start apache with exec

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,9 @@ ENV ENABLE_ID_OBFUSCATION=false
 ENV REDACT_IP_ADDRESSES=false
 ENV WEBPORT=80
 
+# https://httpd.apache.org/docs/2.4/stopping.html#gracefulstop
+STOPSIGNAL SIGWINCH
+
 # Final touches
 EXPOSE 80
 CMD ["bash", "/entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -88,4 +88,4 @@ fi
 echo "Done, Starting APACHE"
 
 # This runs apache
-apache2-foreground
+exec apache2-foreground


### PR DESCRIPTION
Currently we're directly starting apache2 from within the entrypoint script. This has some unintended side effects:

```sh
docker top speedtest
```

```
UID                 PID                 PPID                C                   STIME               TTY                 TIME                CMD
root                18397               18367               0                   20:22               ?                   00:00:00            bash /entrypoint.sh
root                18626               18397               0                   20:22               ?                   00:00:00            apache2 -DFOREGROUND
www-data            18726               18626               0                   20:22               ?                   00:00:00            apache2 -DFOREGROUND
www-data            18727               18626               0                   20:22               ?                   00:00:00            apache2 -DFOREGROUND
www-data            18728               18626               0                   20:22               ?                   00:00:00            apache2 -DFOREGROUND
www-data            18729               18626               0                   20:22               ?                   00:00:00            apache2 -DFOREGROUND
www-data            18730               18626               0                   20:22               ?                   00:00:00            apache2 -DFOREGROUND
www-data            18851               18626               0                   20:22               ?                   00:00:00            apache2 -DFOREGROUND
www-data            19298               18626               1                   20:23               ?                   00:00:00            apache2 -DFOREGROUND
www-data            19300               18626               0                   20:23               ?                   00:00:00            apache2 -DFOREGROUND
www-data            19301               18626               0                   20:23               ?                   00:00:00            apache2 -DFOREGROUND
www-data            19303               18626               0                   20:23               ?                   00:00:00            apache2 -DFOREGROUND
```

Note that the bash process remains alive all the time. The problem is that docker sends (stop) signals to the parent process, which in our case is bash. Without special traps, bash will simply ignore them.

Solution: let apache replace the bash process using `exec`

This also defines the proper stop signal expected by apache.