### PR TITLE
fix: download speed is 0 on certain platform

### DIFF
--- a/backend/garbage.php
+++ b/backend/garbage.php
@@ -53,11 +53,7 @@ function sendHeaders()
 $chunks = getChunkCount();
 
 // Generate data
-if (function_exists('random_bytes')) {
-    $data = random_bytes(1048576);
-} else {
-    $data = openssl_random_pseudo_bytes(1048576);
-}
+$data = openssl_random_pseudo_bytes(1048576);
 
 // Deliver chunks of 1048576 bytes
 sendHeaders();


### PR DESCRIPTION
Reverting this commit fixed #613 for me. Tested with my own build `ghcr.io/zypa13510/librespeed`.
I'm not exactly sure why, not a PHP expert, but my guess is that the `random_byte()` call could be using CSPRNG which is slower. If that is the case, I believe it is perfectly fine to not use CSPRNG, as this is just a speed test not a password generator.

Revert: fa0ac8cd2336052286cd3556889449660e4d9c83, #487
Close: #613 