### PR TITLE
feat: aggregate statistics from stored telemetry

### DIFF
--- a/doc.md
+++ b/doc.md
@@ -155,6 +155,22 @@ A basic front-end for visualizing and searching tests by ID is available in `res
 
 A login is required to access the interface. __Important__: change the default password in `results/telemetry_settings.php`.
 
+##### Aggregate statistics
+
+`results/stats.php` also shows a monthly summary: test counts, download and upload percentiles, a breakdown by client, by address family and by country. It is computed from the telemetry you already store and needs no extra configuration.
+
+Summaries are cached rather than recomputed per page view, in `$stats_cache_dir` (the system temporary directory when left empty). A finished month is computed once; the current month is refreshed at most hourly.
+
+To publish the summary without a login, set `$stats_public_report` to `true`. `results/stats_public.php` then serves the most recent finished month. It only ever reads a cached summary and never queries the database itself, so the number of visitors does not affect the load on your server. Generate the summaries from cron:
+
+```
+0 3 * * * php /path/to/results/stats_build.php
+```
+
+Without that job the public page reports that no summary is available yet, rather than building one on a visitor's request.
+
+Only aggregates are published. Groups of fewer than 100 tests are not reported separately; they are folded into an "Other" row, which is itself omitted unless it reaches the same threshold, so a withheld group cannot be recovered by subtracting the visible ones from the total. Individual results, IP addresses and User-Agent strings are never shown.
+
 #### The end
 
 Now that the test is installed, the default page uses telemetry and results sharing. If you want another UI, you can easily customize `index.html` or one of the examples in the `examples` folder (the best starting point for most people is `example-singleServer-gauges.html`).

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "LibreSpeed - A Free and Open Source speed test that you can host on your server(s)",
   "main": "speedtest.js",
   "scripts": {
-    "test": "echo \"No automated tests configured yet\" && exit 0",
+    "test": "php tests/telemetry_stats_test.php",
     "test:e2e": "playwright test",
     "test:e2e:headed": "playwright test --headed",
     "lint": "eslint speedtest.js speedtest_worker.js stability_worker.js",

--- a/results/index.php
+++ b/results/index.php
@@ -31,6 +31,15 @@ function tryFont($name)
  */
 function format($d)
 {
+    // Rows written before the telemetry endpoint validated its input can hold
+    // anything, and the columns are declared `text` in every schema. An empty
+    // string reaching number_format() is a TypeError on PHP 8, which killed the
+    // whole image before its Content-Type header was even sent, so a result
+    // with a blank measurement answered 500 rather than drawing a zero.
+    if (!is_numeric($d)) {
+        $d = 0;
+    }
+
     if ($d < 10) {
         return number_format($d, 2, '.', '');
     }

--- a/results/stats.php
+++ b/results/stats.php
@@ -4,6 +4,8 @@ error_reporting(0);
 
 require 'telemetry_settings.php';
 require_once 'telemetry_db.php';
+require_once 'stats_summary.php';
+require_once 'stats_render.php';
 
 header('Content-Type: text/html; charset=utf-8');
 header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0, s-maxage=0');
@@ -13,6 +15,7 @@ header('Pragma: no-cache');
 <!DOCTYPE html>
 <html>
     <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <title>LibreSpeed - Stats</title>
         <style type="text/css">
             html,body{
@@ -59,6 +62,7 @@ header('Pragma: no-cache');
                 margin: 1em 0;
             }
         </style>
+        <?php echo statsRenderHead(); ?>
     </head>
     <body>
         <h1>LibreSpeed - Stats</h1>
@@ -74,6 +78,31 @@ header('Pragma: no-cache');
             } else {
                 ?>
                 <form action="stats.php" method="GET"><input type="hidden" name="op" value="logout" /><input type="submit" value="Logout" /></form>
+                <?php
+                // The summary is cached, so revisiting this page does not
+                // re-scan the table; only the first view of an open month does.
+                $statsMonth = statsCurrentMonth();
+                if (isset($_GET['month']) && is_string($_GET['month']) && preg_match('/^\d{4}-\d{2}$/', $_GET['month'])) {
+                    $statsMonth = $_GET['month'];
+                }
+                $statsSummary = statsMonthlySummary($statsMonth);
+                ?>
+                <form action="stats.php" method="GET">
+                    <h3>Aggregate statistics</h3>
+                    <input type="month" name="month" value="<?php echo statsEscape($statsMonth); ?>" />
+                    <input type="submit" value="Show" />
+                </form>
+                <?php
+                if (null === $statsSummary) {
+                    echo '<div>There was an error trying to summarise telemetry for '.statsEscape($statsMonth).'.</div>';
+                } else {
+                    echo statsRenderSummary($statsSummary);
+                    if (isset($stats_public_report) && true === $stats_public_report) {
+                        echo '<div>This summary is also published without a login at '
+                            .'<a href="stats_public.php">stats_public.php</a>.</div>';
+                    }
+                }
+                ?>
                 <form action="stats.php" method="GET">
                     <h3>Search test results</h3>
                     <input type="hidden" name="op" value="id" />

--- a/results/stats_build.php
+++ b/results/stats_build.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * Builds cached monthly summaries. Intended for cron, not for the web.
+ *
+ * Usage:
+ *   php stats_build.php [YYYY-MM ...]
+ *
+ * With no arguments it rebuilds the current month and the one before it, which
+ * is what a nightly job wants: the current month keeps moving, and the previous
+ * one needs a final pass once it closes.
+ *
+ * Running this from cron is what lets stats_public.php stay read-only. Without
+ * it, the public report simply reports that no summary exists yet rather than
+ * building one on a visitor's request.
+ */
+
+if (PHP_SAPI !== 'cli') {
+    header('HTTP/1.1 403 Forbidden');
+    exit("This script is meant to be run from the command line.\n");
+}
+
+chdir(__DIR__);
+require_once __DIR__.'/stats_summary.php';
+
+$months = array_slice($argv, 1);
+if (!$months) {
+    $months = [statsPreviousMonth(), statsCurrentMonth()];
+}
+
+$status = 0;
+foreach ($months as $month) {
+    $bounds = statsMonthBounds($month);
+    if (null === $bounds) {
+        fwrite(STDERR, "not a month: $month\n");
+        $status = 1;
+
+        continue;
+    }
+
+    $started = microtime(true);
+    // maxAge 0 forces a rebuild even when a cached copy is fresh.
+    $summary = statsMonthlySummary($month, 0);
+    if (null === $summary) {
+        fwrite(STDERR, "failed to build $month\n");
+        $status = 1;
+
+        continue;
+    }
+
+    printf(
+        "%s: %d tests, %d without a usable download figure, %.1fs\n",
+        $month,
+        $summary['tests'],
+        $summary['malformed'],
+        microtime(true) - $started
+    );
+}
+
+exit($status);

--- a/results/stats_public.php
+++ b/results/stats_public.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * Public monthly aggregate report.
+ *
+ * Off unless $stats_public_report is enabled. It answers only from a cached
+ * summary and never queries the database on a visitor's behalf, so the cost of
+ * serving it is the cost of reading one small file however many people ask at
+ * once. The month being reported is always a finished one, which is both the
+ * reason the cache can be permanent and the reason the figures do not shift
+ * under a reader.
+ */
+
+require 'telemetry_settings.php';
+require_once 'stats_summary.php';
+require_once 'stats_render.php';
+
+header('Content-Type: text/html; charset=utf-8');
+
+$enabled = isset($stats_public_report) && true === $stats_public_report;
+
+// Default to the most recent finished month, and refuse to serve any other
+// kind. The current month is still being written to, so publishing it would
+// mean figures that move under a reader and disagree with a copy taken an hour
+// earlier. stats.php shows it to a logged-in operator, where that is expected;
+// a public report should only carry a month that is done.
+$month = statsPreviousMonth();
+if (isset($_GET['month']) && is_string($_GET['month']) && preg_match('/^\d{4}-\d{2}$/', $_GET['month'])) {
+    $month = $_GET['month'];
+}
+$finished = $month < statsCurrentMonth();
+
+// A visitor never triggers a build: an uncached month simply is not available
+// yet. Otherwise a request for an arbitrary month would be a way to ask the
+// server to scan its telemetry table, which is exactly what this page exists to
+// avoid. Summaries are produced by stats.php or by running stats_build.php.
+$summary = ($enabled && $finished) ? statsMonthlySummary($month, 3600, false) : null;
+
+?>
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>LibreSpeed - Statistics</title>
+        <?php echo statsRenderHead(); ?>
+        <style>
+            html{ background:var(--ls-page); font-family:"Inter","Segoe UI","Roboto",sans-serif; }
+            body{ max-width:60em; margin:0 auto; padding:2em 1em; color:var(--ls-text); }
+            h1{ font-weight:300; }
+            a{ color:var(--ls-dl); }
+            .ls-months{ margin:1em 0; color:var(--ls-dim); font-size:.9em; }
+        </style>
+    </head>
+    <body>
+        <h1>LibreSpeed statistics</h1>
+        <?php
+        if (!$enabled) {
+            echo '<p>Public statistics are not enabled on this server.</p>';
+        } elseif (!$finished) {
+            echo '<p>'.statsEscape($month).' is still in progress. Reports are published once a month is complete.</p>';
+        } elseif (null === $summary) {
+            echo '<p>No report has been generated for '.statsEscape($month).' yet.</p>';
+        } else {
+            echo statsRenderSummary($summary);
+
+            $months = [];
+            for ($i = 1; $i <= 6; ++$i) {
+                $m = gmdate('Y-m', strtotime(statsCurrentMonth().'-01 12:00:00 -'.$i.' month'));
+                if (null !== statsMonthlySummary($m, 3600, false)) {
+                    $months[] = '<a href="?month='.statsEscape($m).'">'.statsEscape($m).'</a>';
+                }
+            }
+            if ($months) {
+                echo '<p class="ls-months">Other months: '.implode(' · ', $months).'</p>';
+            }
+        }
+        ?>
+    </body>
+</html>

--- a/results/stats_render.php
+++ b/results/stats_render.php
@@ -1,0 +1,372 @@
+<?php
+
+/**
+ * Rendering for the aggregate telemetry summary.
+ *
+ * Shared by the authenticated stats page and the public monthly report so the
+ * two cannot drift apart. The styling is inline rather than pulled from
+ * frontend/styling: the results folder is optional and documented as something
+ * a deployment may install on its own, so it cannot assume the frontend is
+ * there to link against.
+ */
+
+/**
+ * @param float|null $mbps
+ *
+ * @return string
+ */
+function statsFormatSpeed($mbps)
+{
+    if (null === $mbps) {
+        return '—';
+    }
+    if ($mbps >= 1000) {
+        return number_format($mbps / 1000, 2, '.', '').' Gbit/s';
+    }
+    if ($mbps >= 100) {
+        return number_format($mbps, 0, '.', ' ').' Mbit/s';
+    }
+
+    return number_format($mbps, 1, '.', '').' Mbit/s';
+}
+
+/**
+ * @param float $ms
+ *
+ * @return string
+ */
+function statsFormatLatency($ms)
+{
+    return null === $ms ? '—' : number_format($ms, 1, '.', '').' ms';
+}
+
+/**
+ * @param int $n
+ *
+ * @return string
+ */
+function statsFormatCount($n)
+{
+    return number_format((int) $n, 0, '.', ' ');
+}
+
+/**
+ * @param string $s
+ *
+ * @return string
+ */
+function statsEscape($s)
+{
+    return htmlspecialchars((string) $s, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+}
+
+/**
+ * The styles and the theme toggle, for the document head.
+ *
+ * @return string
+ */
+function statsRenderHead()
+{
+    return <<<'CSS'
+<style>
+    :root{
+        --ls-page:#0b0616; --ls-card:#0e0720; --ls-panel:#17102a; --ls-edge:#2a2040;
+        --ls-text:#ffffff; --ls-dim:#898591; --ls-dl:#5cf9fd; --ls-ul:#d63bc6;
+    }
+    /* The modern frontend is dark, so that is the default. The accents from
+       colors.css are chosen against a dark background and are unreadable on a
+       light one, so the light theme darkens them rather than reusing them. */
+    @media (prefers-color-scheme: light){
+        :root{
+            --ls-page:#ececed; --ls-card:#ffffff; --ls-panel:#f6f6f9; --ls-edge:#dcdce4;
+            --ls-text:#16121f; --ls-dim:#66636f; --ls-dl:#0d7f95; --ls-ul:#a3229a;
+        }
+    }
+    /* An explicit choice outranks the system preference. Attribute selectors
+       are more specific than the bare :root above, and a media query adds no
+       specificity of its own, so these win in both directions. */
+    :root[data-ls-theme="light"]{
+        --ls-page:#ececed; --ls-card:#ffffff; --ls-panel:#f6f6f9; --ls-edge:#dcdce4;
+        --ls-text:#16121f; --ls-dim:#66636f; --ls-dl:#0d7f95; --ls-ul:#a3229a;
+    }
+    :root[data-ls-theme="dark"]{
+        --ls-page:#0b0616; --ls-card:#0e0720; --ls-panel:#17102a; --ls-edge:#2a2040;
+        --ls-text:#ffffff; --ls-dim:#898591; --ls-dl:#5cf9fd; --ls-ul:#d63bc6;
+    }
+    .ls-theme{
+        margin-left:auto; cursor:pointer;
+        background:var(--ls-panel); color:var(--ls-dim);
+        border:1px solid var(--ls-edge); border-radius:99px;
+        font:inherit; font-size:.8em; padding:.35em .9em;
+    }
+    .ls-theme:hover{ color:var(--ls-text); }
+    /* Without scripting there is nothing to toggle, and a dead control is
+       worse than none: the page still follows the system preference. */
+    .ls-theme[hidden]{ display:none; }
+    /* The results pages ship no CSS reset, so padding would otherwise be added
+       to every width below — enough to push two summary cards past a phone. */
+    .ls-stats, .ls-stats *{ box-sizing:border-box; }
+    .ls-stats{
+        max-width:100%;
+        background:var(--ls-card); color:var(--ls-text);
+        font-family:"Inter","Segoe UI","Roboto",sans-serif;
+        border-radius:14px; padding:1.5em; margin:2em 0;
+    }
+    .ls-head{ display:flex; flex-wrap:wrap; align-items:baseline; gap:.6em; }
+    .ls-head .ls-mark{ font-size:1.15em; font-weight:600; }
+    .ls-head .ls-server{ color:var(--ls-dim); font-size:.95em; }
+    .ls-stats h2,.ls-stats h3{ color:var(--ls-text); font-weight:600; margin:0 0 .2em 0; }
+    .ls-stats h3{ font-size:.85em; letter-spacing:.12em; text-transform:uppercase; color:var(--ls-dim); margin-top:2em; }
+    .ls-stats .ls-note{ color:var(--ls-dim); font-size:.85em; margin:.4em 0 0 0; }
+    .ls-cards{ display:flex; flex-wrap:wrap; gap:.8em; margin:1.2em 0; }
+    .ls-card{ flex:1 1 10em; background:var(--ls-panel); border:1px solid var(--ls-edge); border-radius:12px; padding:1em; }
+    .ls-card .ls-label{ color:var(--ls-dim); font-size:.8em; letter-spacing:.08em; text-transform:uppercase; }
+    .ls-card .ls-value{ font-size:1.8em; font-weight:300; margin-top:.15em; }
+    .ls-stats table{ width:100%; border-collapse:collapse; margin:.8em 0 0 0; border:none; }
+    .ls-stats table,.ls-stats tr,.ls-stats th,.ls-stats td{ border:none; }
+    .ls-stats th{ width:auto; text-align:left; color:var(--ls-dim); font-weight:600;
+        font-size:.78em; letter-spacing:.08em; text-transform:uppercase;
+        padding:.5em .6em; border-bottom:1px solid var(--ls-edge); }
+    .ls-stats td{ padding:.5em .6em; border-bottom:1px solid var(--ls-edge); word-break:normal; }
+    .ls-stats td.ls-num,.ls-stats th.ls-num{ text-align:right; font-variant-numeric:tabular-nums; }
+    .ls-bar{ background:var(--ls-edge); border-radius:99px; height:.5em; overflow:hidden; min-width:6em; }
+    .ls-bar span{ display:block; height:100%; background:var(--ls-dl); }
+    .ls-bar.ls-ul span{ background:var(--ls-ul); }
+    /* The client table carries eight columns, which no phone fits. Letting it
+       scroll inside its own box keeps the page itself from scrolling sideways,
+       which is the part that makes a layout feel broken. */
+    .ls-scroll{ overflow-x:auto; }
+    @media (max-width:40em){
+        .ls-stats{ padding:1em; border-radius:10px; margin:1em 0; }
+        .ls-card .ls-value{ font-size:1.5em; }
+        .ls-stats th,.ls-stats td{ padding:.45em .5em; white-space:nowrap; }
+        .ls-stats h3{ margin-top:1.5em; }
+    }
+</style>
+<script>
+(function () {
+    var KEY = 'librespeed-stats-theme';
+    var root = document.documentElement;
+
+    function stored() {
+        try {
+            var v = window.localStorage.getItem(KEY);
+            return v === 'light' || v === 'dark' ? v : null;
+        } catch (e) {
+            // Private browsing can refuse localStorage outright. The toggle
+            // still works for the current page; it just will not be remembered.
+            return null;
+        }
+    }
+
+    function systemTheme() {
+        return window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches
+            ? 'light'
+            : 'dark';
+    }
+
+    function current() {
+        return root.getAttribute('data-ls-theme') || systemTheme();
+    }
+
+    // Applied before the body is parsed, so the page never paints the wrong
+    // theme first and corrects itself.
+    var saved = stored();
+    if (saved) {
+        root.setAttribute('data-ls-theme', saved);
+    }
+
+    function label(button) {
+        button.textContent = current() === 'dark' ? 'Light theme' : 'Dark theme';
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+        var buttons = document.querySelectorAll('[data-ls-theme-toggle]');
+        Array.prototype.forEach.call(buttons, function (button) {
+            button.hidden = false;
+            label(button);
+            button.addEventListener('click', function () {
+                var next = current() === 'dark' ? 'light' : 'dark';
+                root.setAttribute('data-ls-theme', next);
+                try {
+                    window.localStorage.setItem(KEY, next);
+                } catch (e) {
+                    // As above: not remembering is acceptable, failing is not.
+                }
+                Array.prototype.forEach.call(buttons, label);
+            });
+        });
+    });
+})();
+</script>
+CSS;
+}
+
+/**
+ * Names the server the figures came from.
+ *
+ * A report is read as a screenshot or a PDF as often as in a browser, and by
+ * then the address bar is gone. Without this the numbers do not say whose they
+ * are. $stats_title is preferred over the requested host, which is set by the
+ * client and can be anything.
+ *
+ * @return string
+ */
+function statsServerName()
+{
+    require TELEMETRY_SETTINGS_FILE;
+
+    if (isset($stats_title) && '' !== trim((string) $stats_title)) {
+        return trim((string) $stats_title);
+    }
+
+    if (isset($_SERVER['HTTP_HOST']) && is_string($_SERVER['HTTP_HOST'])) {
+        return $_SERVER['HTTP_HOST'];
+    }
+
+    return '';
+}
+
+/**
+ * @param array $summary
+ *
+ * @return string
+ */
+function statsRenderSummary(array $summary)
+{
+    $h = '<div class="ls-stats">';
+
+    $server = statsServerName();
+    $h .= '<div class="ls-head"><span class="ls-mark">LibreSpeed</span>';
+    if ('' !== $server) {
+        $h .= '<span class="ls-server">'.statsEscape($server).'</span>';
+    }
+    $h .= '<button type="button" class="ls-theme" data-ls-theme-toggle hidden></button>';
+    $h .= '</div>';
+
+    $h .= '<h2>Telemetry overview</h2>';
+    $h .= '<p class="ls-note">'.statsEscape(substr($summary['from'], 0, 10)).' to '
+        .statsEscape(substr($summary['to'], 0, 10)).', generated '.statsEscape($summary['generated']).'</p>';
+
+    $cards = [
+        ['Tests', statsFormatCount($summary['tests'])],
+        ['Median download', $summary['download'] ? statsFormatSpeed($summary['download']['p50']) : '—'],
+        ['Median upload', $summary['upload'] ? statsFormatSpeed($summary['upload']['p50']) : '—'],
+        ['Median ping', $summary['ping'] ? statsFormatLatency($summary['ping']['p50']) : '—'],
+    ];
+    $h .= '<div class="ls-cards">';
+    foreach ($cards as $card) {
+        $h .= '<div class="ls-card"><div class="ls-label">'.statsEscape($card[0])
+            .'</div><div class="ls-value">'.statsEscape($card[1]).'</div></div>';
+    }
+    $h .= '</div>';
+
+    if ($summary['tests'] < 1) {
+        return $h.'<p class="ls-note">No tests recorded in this period.</p></div>';
+    }
+
+    // Distribution
+    if ($summary['download']) {
+        $h .= '<h3>Download distribution</h3>';
+        $h .= '<div class="ls-scroll"><table><tr><th>Percentile</th><th class="ls-num">Download</th><th class="ls-num">Upload</th></tr>';
+        foreach ([10, 25, 50, 75, 90] as $p) {
+            $h .= '<tr><td>P'.$p.'</td><td class="ls-num">'.statsEscape(statsFormatSpeed($summary['download']['p'.$p]))
+                .'</td><td class="ls-num">'
+                .statsEscape($summary['upload'] ? statsFormatSpeed($summary['upload']['p'.$p]) : '—')
+                .'</td></tr>';
+        }
+        $h .= '<tr><td>Mean</td><td class="ls-num">'.statsEscape(statsFormatSpeed($summary['download']['mean']))
+            .'</td><td class="ls-num">'
+            .statsEscape($summary['upload'] ? statsFormatSpeed($summary['upload']['mean']) : '—')
+            .'</td></tr>';
+        $h .= '</table></div>';
+        $h .= '<p class="ls-note">Percentiles are resolved to '
+            .statsEscape((string) $summary['speed_resolution']).' Mbit/s. The mean is exact, and is the figure most'
+            .' affected by a handful of very fast or fabricated results.</p>';
+    }
+
+    // Clients
+    if (!empty($summary['clients'])) {
+        $h .= '<h3>Clients</h3>';
+        $h .= '<div class="ls-scroll"><table><tr><th>Client</th><th class="ls-num">Tests</th><th class="ls-num">Mean DL</th>'
+            .'<th class="ls-num">Median DL</th><th class="ls-num">P90 DL</th>'
+            .'<th class="ls-num">Mean UL</th><th class="ls-num">Median UL</th>'
+            .'<th class="ls-num">IPv6</th></tr>';
+        foreach ($summary['clients'] as $name => $c) {
+            if ('Other' === $name && !isset($c['download'])) {
+                $h .= '<tr><td>Other</td><td class="ls-num">'.statsFormatCount($c['tests'])
+                    .'</td><td class="ls-num" colspan="6">'.statsEscape($c['groups'])
+                    .' groups below the reporting threshold</td></tr>';
+
+                continue;
+            }
+            $total = array_sum($c['families']);
+            $v6 = isset($c['families']['IPv6']) ? $c['families']['IPv6'] : 0;
+            $h .= '<tr><td>'.statsEscape($name).'</td>'
+                .'<td class="ls-num">'.statsFormatCount($c['tests']).'</td>'
+                .'<td class="ls-num">'.statsEscape($c['download'] ? statsFormatSpeed($c['download']['mean']) : '—').'</td>'
+                .'<td class="ls-num">'.statsEscape($c['download'] ? statsFormatSpeed($c['download']['p50']) : '—').'</td>'
+                .'<td class="ls-num">'.statsEscape($c['download'] ? statsFormatSpeed($c['download']['p90']) : '—').'</td>'
+                .'<td class="ls-num">'.statsEscape($c['upload'] ? statsFormatSpeed($c['upload']['mean']) : '—').'</td>'
+                .'<td class="ls-num">'.statsEscape($c['upload'] ? statsFormatSpeed($c['upload']['p50']) : '—').'</td>'
+                .'<td class="ls-num">'.($total > 0 ? number_format($v6 / $total * 100, 1).'&nbsp;%' : '—').'</td></tr>';
+        }
+        $h .= '</table></div>';
+        $h .= '<p class="ls-note">Clients are grouped from the User-Agent, which is chosen by the sender:'
+            .' this describes what clients report themselves as. Individual User-Agent strings are never shown.</p>';
+    }
+
+    // Address family
+    if (!empty($summary['families'])) {
+        $totalFam = 0;
+        foreach ($summary['families'] as $f) {
+            $totalFam += $f['tests'];
+        }
+        $h .= '<h3>IPv4 and IPv6</h3><div class="ls-scroll"><table>';
+        $h .= '<tr><th>Family</th><th class="ls-num">Tests</th><th class="ls-num">Share</th>'
+            .'<th class="ls-num">Median DL</th><th style="width:40%"></th></tr>';
+        foreach ($summary['families'] as $name => $f) {
+            $share = $totalFam > 0 ? $f['tests'] / $totalFam * 100 : 0;
+            $h .= '<tr><td>'.statsEscape($name).'</td>'
+                .'<td class="ls-num">'.statsFormatCount($f['tests']).'</td>'
+                .'<td class="ls-num">'.number_format($share, 1).'&nbsp;%</td>'
+                .'<td class="ls-num">'.statsEscape(isset($f['download']) && $f['download'] ? statsFormatSpeed($f['download']['p50']) : '—').'</td>'
+                .'<td><div class="ls-bar"><span style="width:'.number_format($share, 1).'%"></span></div></td></tr>';
+        }
+        $h .= '</table></div>';
+    }
+
+    // Countries
+    if (!empty($summary['countries'])) {
+        $h .= '<h3>Countries</h3><div class="ls-scroll"><table>';
+        $h .= '<tr><th>Country</th><th class="ls-num">Tests</th><th class="ls-num">Median DL</th>'
+            .'<th class="ls-num">Median UL</th><th class="ls-num">IPv6</th></tr>';
+        foreach ($summary['countries'] as $name => $c) {
+            if ('Other' === $name && !isset($c['download'])) {
+                $h .= '<tr><td>Other</td><td class="ls-num">'.statsFormatCount($c['tests'])
+                    .'</td><td class="ls-num" colspan="3">'.statsEscape($c['groups'])
+                    .' countries below the reporting threshold</td></tr>';
+
+                continue;
+            }
+            $h .= '<tr><td>'.statsEscape($name).'</td>'
+                .'<td class="ls-num">'.statsFormatCount($c['tests']).'</td>'
+                .'<td class="ls-num">'.statsEscape($c['download'] ? statsFormatSpeed($c['download']['p50']) : '—').'</td>'
+                .'<td class="ls-num">'.statsEscape($c['upload'] ? statsFormatSpeed($c['upload']['p50']) : '—').'</td>'
+                .'<td class="ls-num">'.number_format($c['ipv6_share'] * 100, 1).'&nbsp;%</td></tr>';
+        }
+        $h .= '</table></div>';
+    }
+
+    $h .= '<p class="ls-note">Aggregate figures only. Groups of fewer than '
+        .statsEscape((string) $summary['threshold'])
+        .' tests are not reported separately, and are collected into "Other" only when that in turn'
+        .' reaches the threshold.';
+    if ($summary['malformed'] > 0) {
+        $h .= ' '.statsFormatCount($summary['malformed']).' of '.statsFormatCount($summary['tests'])
+            .' submissions carried no usable download figure and are counted but not measured.';
+    }
+    $h .= '</p>';
+
+    return $h.'</div>';
+}

--- a/results/stats_render.php
+++ b/results/stats_render.php
@@ -1,0 +1,372 @@
+<?php
+
+/**
+ * Rendering for the aggregate telemetry summary.
+ *
+ * Shared by the authenticated stats page and the public monthly report so the
+ * two cannot drift apart. The styling is inline rather than pulled from
+ * frontend/styling: the results folder is optional and documented as something
+ * a deployment may install on its own, so it cannot assume the frontend is
+ * there to link against.
+ */
+
+/**
+ * @param float|null $mbps
+ *
+ * @return string
+ */
+function statsFormatSpeed($mbps)
+{
+    if (null === $mbps) {
+        return '—';
+    }
+    if ($mbps >= 1000) {
+        return number_format($mbps / 1000, 2, '.', '').' Gbit/s';
+    }
+    if ($mbps >= 100) {
+        return number_format($mbps, 0, '.', ' ').' Mbit/s';
+    }
+
+    return number_format($mbps, 1, '.', '').' Mbit/s';
+}
+
+/**
+ * @param float|null $ms
+ *
+ * @return string
+ */
+function statsFormatLatency($ms)
+{
+    return null === $ms ? '—' : number_format($ms, 1, '.', '').' ms';
+}
+
+/**
+ * @param int $n
+ *
+ * @return string
+ */
+function statsFormatCount($n)
+{
+    return number_format((int) $n, 0, '.', ' ');
+}
+
+/**
+ * @param string $s
+ *
+ * @return string
+ */
+function statsEscape($s)
+{
+    return htmlspecialchars((string) $s, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+}
+
+/**
+ * The styles and the theme toggle, for the document head.
+ *
+ * @return string
+ */
+function statsRenderHead()
+{
+    return <<<'CSS'
+<style>
+    :root{
+        --ls-page:#0b0616; --ls-card:#0e0720; --ls-panel:#17102a; --ls-edge:#2a2040;
+        --ls-text:#ffffff; --ls-dim:#898591; --ls-dl:#5cf9fd; --ls-ul:#d63bc6;
+    }
+    /* The modern frontend is dark, so that is the default. The accents from
+       colors.css are chosen against a dark background and are unreadable on a
+       light one, so the light theme darkens them rather than reusing them. */
+    @media (prefers-color-scheme: light){
+        :root{
+            --ls-page:#ececed; --ls-card:#ffffff; --ls-panel:#f6f6f9; --ls-edge:#dcdce4;
+            --ls-text:#16121f; --ls-dim:#66636f; --ls-dl:#0d7f95; --ls-ul:#a3229a;
+        }
+    }
+    /* An explicit choice outranks the system preference. Attribute selectors
+       are more specific than the bare :root above, and a media query adds no
+       specificity of its own, so these win in both directions. */
+    :root[data-ls-theme="light"]{
+        --ls-page:#ececed; --ls-card:#ffffff; --ls-panel:#f6f6f9; --ls-edge:#dcdce4;
+        --ls-text:#16121f; --ls-dim:#66636f; --ls-dl:#0d7f95; --ls-ul:#a3229a;
+    }
+    :root[data-ls-theme="dark"]{
+        --ls-page:#0b0616; --ls-card:#0e0720; --ls-panel:#17102a; --ls-edge:#2a2040;
+        --ls-text:#ffffff; --ls-dim:#898591; --ls-dl:#5cf9fd; --ls-ul:#d63bc6;
+    }
+    .ls-theme{
+        margin-left:auto; cursor:pointer;
+        background:var(--ls-panel); color:var(--ls-dim);
+        border:1px solid var(--ls-edge); border-radius:99px;
+        font:inherit; font-size:.8em; padding:.35em .9em;
+    }
+    .ls-theme:hover{ color:var(--ls-text); }
+    /* Without scripting there is nothing to toggle, and a dead control is
+       worse than none: the page still follows the system preference. */
+    .ls-theme[hidden]{ display:none; }
+    /* The results pages ship no CSS reset, so padding would otherwise be added
+       to every width below — enough to push two summary cards past a phone. */
+    .ls-stats, .ls-stats *{ box-sizing:border-box; }
+    .ls-stats{
+        max-width:100%;
+        background:var(--ls-card); color:var(--ls-text);
+        font-family:"Inter","Segoe UI","Roboto",sans-serif;
+        border-radius:14px; padding:1.5em; margin:2em 0;
+    }
+    .ls-head{ display:flex; flex-wrap:wrap; align-items:baseline; gap:.6em; }
+    .ls-head .ls-mark{ font-size:1.15em; font-weight:600; }
+    .ls-head .ls-server{ color:var(--ls-dim); font-size:.95em; }
+    .ls-stats h2,.ls-stats h3{ color:var(--ls-text); font-weight:600; margin:0 0 .2em 0; }
+    .ls-stats h3{ font-size:.85em; letter-spacing:.12em; text-transform:uppercase; color:var(--ls-dim); margin-top:2em; }
+    .ls-stats .ls-note{ color:var(--ls-dim); font-size:.85em; margin:.4em 0 0 0; }
+    .ls-cards{ display:flex; flex-wrap:wrap; gap:.8em; margin:1.2em 0; }
+    .ls-card{ flex:1 1 10em; background:var(--ls-panel); border:1px solid var(--ls-edge); border-radius:12px; padding:1em; }
+    .ls-card .ls-label{ color:var(--ls-dim); font-size:.8em; letter-spacing:.08em; text-transform:uppercase; }
+    .ls-card .ls-value{ font-size:1.8em; font-weight:300; margin-top:.15em; }
+    .ls-stats table{ width:100%; border-collapse:collapse; margin:.8em 0 0 0; border:none; }
+    .ls-stats table,.ls-stats tr,.ls-stats th,.ls-stats td{ border:none; }
+    .ls-stats th{ width:auto; text-align:left; color:var(--ls-dim); font-weight:600;
+        font-size:.78em; letter-spacing:.08em; text-transform:uppercase;
+        padding:.5em .6em; border-bottom:1px solid var(--ls-edge); }
+    .ls-stats td{ padding:.5em .6em; border-bottom:1px solid var(--ls-edge); word-break:normal; }
+    .ls-stats td.ls-num,.ls-stats th.ls-num{ text-align:right; font-variant-numeric:tabular-nums; }
+    .ls-bar{ background:var(--ls-edge); border-radius:99px; height:.5em; overflow:hidden; min-width:6em; }
+    .ls-bar span{ display:block; height:100%; background:var(--ls-dl); }
+    .ls-bar.ls-ul span{ background:var(--ls-ul); }
+    /* The client table carries eight columns, which no phone fits. Letting it
+       scroll inside its own box keeps the page itself from scrolling sideways,
+       which is the part that makes a layout feel broken. */
+    .ls-scroll{ overflow-x:auto; }
+    @media (max-width:40em){
+        .ls-stats{ padding:1em; border-radius:10px; margin:1em 0; }
+        .ls-card .ls-value{ font-size:1.5em; }
+        .ls-stats th,.ls-stats td{ padding:.45em .5em; white-space:nowrap; }
+        .ls-stats h3{ margin-top:1.5em; }
+    }
+</style>
+<script>
+(function () {
+    var KEY = 'librespeed-stats-theme';
+    var root = document.documentElement;
+
+    function stored() {
+        try {
+            var v = window.localStorage.getItem(KEY);
+            return v === 'light' || v === 'dark' ? v : null;
+        } catch (e) {
+            // Private browsing can refuse localStorage outright. The toggle
+            // still works for the current page; it just will not be remembered.
+            return null;
+        }
+    }
+
+    function systemTheme() {
+        return window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches
+            ? 'light'
+            : 'dark';
+    }
+
+    function current() {
+        return root.getAttribute('data-ls-theme') || systemTheme();
+    }
+
+    // Applied before the body is parsed, so the page never paints the wrong
+    // theme first and corrects itself.
+    var saved = stored();
+    if (saved) {
+        root.setAttribute('data-ls-theme', saved);
+    }
+
+    function label(button) {
+        button.textContent = current() === 'dark' ? 'Light theme' : 'Dark theme';
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+        var buttons = document.querySelectorAll('[data-ls-theme-toggle]');
+        Array.prototype.forEach.call(buttons, function (button) {
+            button.hidden = false;
+            label(button);
+            button.addEventListener('click', function () {
+                var next = current() === 'dark' ? 'light' : 'dark';
+                root.setAttribute('data-ls-theme', next);
+                try {
+                    window.localStorage.setItem(KEY, next);
+                } catch (e) {
+                    // As above: not remembering is acceptable, failing is not.
+                }
+                Array.prototype.forEach.call(buttons, label);
+            });
+        });
+    });
+})();
+</script>
+CSS;
+}
+
+/**
+ * Names the server the figures came from.
+ *
+ * A report is read as a screenshot or a PDF as often as in a browser, and by
+ * then the address bar is gone. Without this the numbers do not say whose they
+ * are. $stats_title is preferred over the requested host, which is set by the
+ * client and can be anything.
+ *
+ * @return string
+ */
+function statsServerName()
+{
+    require TELEMETRY_SETTINGS_FILE;
+
+    if (isset($stats_title) && '' !== trim((string) $stats_title)) {
+        return trim((string) $stats_title);
+    }
+
+    if (isset($_SERVER['HTTP_HOST']) && is_string($_SERVER['HTTP_HOST'])) {
+        return $_SERVER['HTTP_HOST'];
+    }
+
+    return '';
+}
+
+/**
+ * @param array $summary
+ *
+ * @return string
+ */
+function statsRenderSummary(array $summary)
+{
+    $h = '<div class="ls-stats">';
+
+    $server = statsServerName();
+    $h .= '<div class="ls-head"><span class="ls-mark">LibreSpeed</span>';
+    if ('' !== $server) {
+        $h .= '<span class="ls-server">'.statsEscape($server).'</span>';
+    }
+    $h .= '<button type="button" class="ls-theme" data-ls-theme-toggle hidden></button>';
+    $h .= '</div>';
+
+    $h .= '<h2>Telemetry overview</h2>';
+    $h .= '<p class="ls-note">'.statsEscape(substr($summary['from'], 0, 10)).' to '
+        .statsEscape(substr($summary['to'], 0, 10)).', generated '.statsEscape($summary['generated']).'</p>';
+
+    $cards = [
+        ['Tests', statsFormatCount($summary['tests'])],
+        ['Median download', $summary['download'] ? statsFormatSpeed($summary['download']['p50']) : '—'],
+        ['Median upload', $summary['upload'] ? statsFormatSpeed($summary['upload']['p50']) : '—'],
+        ['Median ping', $summary['ping'] ? statsFormatLatency($summary['ping']['p50']) : '—'],
+    ];
+    $h .= '<div class="ls-cards">';
+    foreach ($cards as $card) {
+        $h .= '<div class="ls-card"><div class="ls-label">'.statsEscape($card[0])
+            .'</div><div class="ls-value">'.statsEscape($card[1]).'</div></div>';
+    }
+    $h .= '</div>';
+
+    if ($summary['tests'] < 1) {
+        return $h.'<p class="ls-note">No tests recorded in this period.</p></div>';
+    }
+
+    // Distribution
+    if ($summary['download']) {
+        $h .= '<h3>Download distribution</h3>';
+        $h .= '<div class="ls-scroll"><table><tr><th>Percentile</th><th class="ls-num">Download</th><th class="ls-num">Upload</th></tr>';
+        foreach ([10, 25, 50, 75, 90] as $p) {
+            $h .= '<tr><td>P'.$p.'</td><td class="ls-num">'.statsEscape(statsFormatSpeed($summary['download']['p'.$p]))
+                .'</td><td class="ls-num">'
+                .statsEscape($summary['upload'] ? statsFormatSpeed($summary['upload']['p'.$p]) : '—')
+                .'</td></tr>';
+        }
+        $h .= '<tr><td>Mean</td><td class="ls-num">'.statsEscape(statsFormatSpeed($summary['download']['mean']))
+            .'</td><td class="ls-num">'
+            .statsEscape($summary['upload'] ? statsFormatSpeed($summary['upload']['mean']) : '—')
+            .'</td></tr>';
+        $h .= '</table></div>';
+        $h .= '<p class="ls-note">Percentiles are resolved to '
+            .statsEscape((string) $summary['speed_resolution']).' Mbit/s. The mean is exact, and is the figure most'
+            .' affected by a handful of very fast or fabricated results.</p>';
+    }
+
+    // Clients
+    if (!empty($summary['clients'])) {
+        $h .= '<h3>Clients</h3>';
+        $h .= '<div class="ls-scroll"><table><tr><th>Client</th><th class="ls-num">Tests</th><th class="ls-num">Mean DL</th>'
+            .'<th class="ls-num">Median DL</th><th class="ls-num">P90 DL</th>'
+            .'<th class="ls-num">Mean UL</th><th class="ls-num">Median UL</th>'
+            .'<th class="ls-num">IPv6</th></tr>';
+        foreach ($summary['clients'] as $name => $c) {
+            if ('Other' === $name && !isset($c['download'])) {
+                $h .= '<tr><td>Other</td><td class="ls-num">'.statsFormatCount($c['tests'])
+                    .'</td><td class="ls-num" colspan="6">'.statsEscape($c['groups'])
+                    .' groups below the reporting threshold</td></tr>';
+
+                continue;
+            }
+            $total = array_sum($c['families']);
+            $v6 = isset($c['families']['IPv6']) ? $c['families']['IPv6'] : 0;
+            $h .= '<tr><td>'.statsEscape($name).'</td>'
+                .'<td class="ls-num">'.statsFormatCount($c['tests']).'</td>'
+                .'<td class="ls-num">'.statsEscape($c['download'] ? statsFormatSpeed($c['download']['mean']) : '—').'</td>'
+                .'<td class="ls-num">'.statsEscape($c['download'] ? statsFormatSpeed($c['download']['p50']) : '—').'</td>'
+                .'<td class="ls-num">'.statsEscape($c['download'] ? statsFormatSpeed($c['download']['p90']) : '—').'</td>'
+                .'<td class="ls-num">'.statsEscape($c['upload'] ? statsFormatSpeed($c['upload']['mean']) : '—').'</td>'
+                .'<td class="ls-num">'.statsEscape($c['upload'] ? statsFormatSpeed($c['upload']['p50']) : '—').'</td>'
+                .'<td class="ls-num">'.($total > 0 ? number_format($v6 / $total * 100, 1).'&nbsp;%' : '—').'</td></tr>';
+        }
+        $h .= '</table></div>';
+        $h .= '<p class="ls-note">Clients are grouped from the User-Agent, which is chosen by the sender:'
+            .' this describes what clients report themselves as. Individual User-Agent strings are never shown.</p>';
+    }
+
+    // Address family
+    if (!empty($summary['families'])) {
+        $totalFam = 0;
+        foreach ($summary['families'] as $f) {
+            $totalFam += $f['tests'];
+        }
+        $h .= '<h3>IPv4 and IPv6</h3><div class="ls-scroll"><table>';
+        $h .= '<tr><th>Family</th><th class="ls-num">Tests</th><th class="ls-num">Share</th>'
+            .'<th class="ls-num">Median DL</th><th style="width:40%"></th></tr>';
+        foreach ($summary['families'] as $name => $f) {
+            $share = $totalFam > 0 ? $f['tests'] / $totalFam * 100 : 0;
+            $h .= '<tr><td>'.statsEscape($name).'</td>'
+                .'<td class="ls-num">'.statsFormatCount($f['tests']).'</td>'
+                .'<td class="ls-num">'.number_format($share, 1).'&nbsp;%</td>'
+                .'<td class="ls-num">'.statsEscape(isset($f['download']) && $f['download'] ? statsFormatSpeed($f['download']['p50']) : '—').'</td>'
+                .'<td><div class="ls-bar"><span style="width:'.number_format($share, 1).'%"></span></div></td></tr>';
+        }
+        $h .= '</table></div>';
+    }
+
+    // Countries
+    if (!empty($summary['countries'])) {
+        $h .= '<h3>Countries</h3><div class="ls-scroll"><table>';
+        $h .= '<tr><th>Country</th><th class="ls-num">Tests</th><th class="ls-num">Median DL</th>'
+            .'<th class="ls-num">Median UL</th><th class="ls-num">IPv6</th></tr>';
+        foreach ($summary['countries'] as $name => $c) {
+            if ('Other' === $name && !isset($c['download'])) {
+                $h .= '<tr><td>Other</td><td class="ls-num">'.statsFormatCount($c['tests'])
+                    .'</td><td class="ls-num" colspan="3">'.statsEscape($c['groups'])
+                    .' countries below the reporting threshold</td></tr>';
+
+                continue;
+            }
+            $h .= '<tr><td>'.statsEscape($name).'</td>'
+                .'<td class="ls-num">'.statsFormatCount($c['tests']).'</td>'
+                .'<td class="ls-num">'.statsEscape($c['download'] ? statsFormatSpeed($c['download']['p50']) : '—').'</td>'
+                .'<td class="ls-num">'.statsEscape($c['upload'] ? statsFormatSpeed($c['upload']['p50']) : '—').'</td>'
+                .'<td class="ls-num">'.number_format($c['ipv6_share'] * 100, 1).'&nbsp;%</td></tr>';
+        }
+        $h .= '</table></div>';
+    }
+
+    $h .= '<p class="ls-note">Aggregate figures only. Groups of fewer than '
+        .statsEscape((string) $summary['threshold'])
+        .' tests are not reported separately, and are collected into "Other" only when that in turn'
+        .' reaches the threshold.';
+    if ($summary['malformed'] > 0) {
+        $h .= ' '.statsFormatCount($summary['malformed']).' of '.statsFormatCount($summary['tests'])
+            .' submissions carried no usable download figure and are counted but not measured.';
+    }
+    $h .= '</p>';
+
+    return $h.'</div>';
+}

--- a/results/stats_summary.php
+++ b/results/stats_summary.php
@@ -1,0 +1,545 @@
+<?php
+
+/**
+ * Aggregate telemetry statistics.
+ *
+ * This computes a summary of a period once and caches it, rather than querying
+ * on every page view. That is what makes a public report safe to expose: the
+ * page reads a handful of numbers from a file, so the cost of serving it does
+ * not grow with the size of the table and cannot be used to make the database
+ * do work on demand.
+ *
+ * Everything is derived in PHP rather than in SQL. Medians and percentiles have
+ * no portable spelling across the four supported backends — PostgreSQL and
+ * MSSQL have percentile_cont, MySQL needs window functions, SQLite has neither
+ * — and the measurement columns are declared `text` everywhere, so aggregating
+ * them in SQL means either a cast that a single malformed row can abort or a
+ * silent string comparison that answers the wrong question.
+ */
+
+require_once __DIR__.'/telemetry_db.php';
+
+/**
+ * Groups smaller than this are not reported on their own.
+ *
+ * A country line covering three tests is close to naming a person, so anything
+ * below the threshold is folded into a single "Other" row, and that row is
+ * itself dropped unless it clears the threshold too.
+ *
+ * This hides how the small groups are made up, not that they exist: with the
+ * total shown, their combined size is still the total minus the visible rows,
+ * and where only one group was withheld that is its exact size. What it does
+ * prevent is reporting a measurement for a group too small to report one for.
+ */
+const STATS_PRIVACY_THRESHOLD = 100;
+
+/** Percentiles are resolved to this many Mbit/s. */
+const STATS_SPEED_BUCKET = 1.0;
+
+/** ...and this many milliseconds. */
+const STATS_LATENCY_BUCKET = 0.1;
+
+/**
+ * A running total plus a sparse histogram.
+ *
+ * The histogram is what keeps this usable on a shared host: holding every
+ * measurement to sort it would cost hundreds of megabytes on a busy instance,
+ * while counting into buckets is bounded by the number of distinct buckets, so
+ * a million tests collapse into a few thousand integers. The mean is summed
+ * exactly; only the percentiles carry the bucket's resolution.
+ *
+ * @return array
+ */
+function statsNewSeries()
+{
+    return ['n' => 0, 'sum' => 0.0, 'hist' => []];
+}
+
+/**
+ * @param array      $series
+ * @param float|null $value
+ * @param float      $bucket
+ *
+ * @return void
+ */
+function statsAdd(array &$series, $value, $bucket)
+{
+    if (null === $value) {
+        return;
+    }
+
+    ++$series['n'];
+    $series['sum'] += $value;
+
+    $index = (int) floor($value / $bucket);
+    if (isset($series['hist'][$index])) {
+        ++$series['hist'][$index];
+    } else {
+        $series['hist'][$index] = 1;
+    }
+}
+
+/**
+ * Reduces a series to the figures that get reported.
+ *
+ * @param array $series
+ * @param float $bucket
+ * @param int[] $percentiles
+ *
+ * @return array|null
+ */
+function statsSummarise(array $series, $bucket, array $percentiles = [10, 25, 50, 75, 90])
+{
+    if (0 === $series['n']) {
+        return null;
+    }
+
+    $out = [
+        'tests' => $series['n'],
+        'mean' => $series['sum'] / $series['n'],
+    ];
+
+    $hist = $series['hist'];
+    ksort($hist);
+
+    foreach ($percentiles as $p) {
+        // Nearest-rank: the smallest bucket whose cumulative count reaches the
+        // requested share. Interpolating would suggest a precision the bucket
+        // width does not have.
+        $target = $p / 100 * $series['n'];
+        $seen = 0;
+        $value = 0.0;
+        foreach ($hist as $index => $count) {
+            $seen += $count;
+            if ($seen >= $target) {
+                $value = $index * $bucket;
+
+                break;
+            }
+        }
+        $out['p'.$p] = $value;
+    }
+
+    return $out;
+}
+
+/**
+ * Keeps a group name to text that can be encoded.
+ *
+ * Client and ISP strings are stored exactly as they arrived, so a group name
+ * derived from one can hold any byte sequence. json_encode() refuses invalid
+ * UTF-8 outright, which would leave the summary uncacheable, so anything that
+ * is not valid is reported as unknown rather than carried through.
+ *
+ * @param string $name
+ *
+ * @return string
+ */
+function statsSafeName($name)
+{
+    // //u makes the match fail on invalid UTF-8, which is the cheapest way to
+    // test a string for it.
+    return preg_match('//u', $name) ? $name : 'Unknown';
+}
+
+/**
+ * Names the kind of client a user agent belongs to.
+ *
+ * Deliberately coarse. The user agent is chosen by whoever sends it, so this is
+ * a description of what clients claim to be, not a measurement; a handful of
+ * buckets can be read that way honestly, while a long tail of exact strings
+ * invites treating it as fact. The raw value is never reported.
+ *
+ * @param string $ua
+ *
+ * @return string
+ */
+function statsClassifyClient($ua)
+{
+    $ua = trim((string) $ua);
+    if ('' === $ua) {
+        return 'Unknown';
+    }
+
+    // The Rust port installs under the same binary name as the Go client, so
+    // the longer prefix has to be tested first.
+    if (0 === stripos($ua, 'librespeed-cli-rust/')) {
+        return 'LibreSpeed CLI (Rust)';
+    }
+    if (0 === stripos($ua, 'librespeed-cli/')) {
+        return 'LibreSpeed CLI (Go)';
+    }
+    if (false !== stripos($ua, 'Dalvik') || false !== stripos($ua, 'okhttp')) {
+        return 'Android app';
+    }
+    if (0 === stripos($ua, 'Mozilla/')) {
+        return 'Web browser';
+    }
+
+    return 'Other';
+}
+
+/**
+ * Names the address family without disclosing the address.
+ *
+ * @param string $ip
+ *
+ * @return string
+ */
+function statsAddressFamily($ip)
+{
+    $ip = trim((string) $ip);
+    if ('' === $ip || '0.0.0.0' === $ip) {
+        // What a deployment with redact_ip_addresses stores. Reporting it as
+        // IPv4 would invent a fact.
+        return 'Unknown';
+    }
+
+    return false === strpos($ip, ':') ? 'IPv4' : 'IPv6';
+}
+
+/**
+ * Digs the country out of the stored ISP information.
+ *
+ * There is no country column: the API path leaves it in rawIspInfo, and the
+ * offline database path only glues it onto the end of processedString.
+ *
+ * @param string $ispinfo
+ *
+ * @return string
+ */
+function statsCountry($ispinfo)
+{
+    $decoded = json_decode((string) $ispinfo, true);
+    if (!is_array($decoded)) {
+        return 'Unknown';
+    }
+
+    if (isset($decoded['rawIspInfo']['country']) && is_string($decoded['rawIspInfo']['country'])) {
+        $country = trim($decoded['rawIspInfo']['country']);
+        if ('' !== $country) {
+            return statsSafeName($country);
+        }
+    }
+
+    if (isset($decoded['processedString']) && is_string($decoded['processedString'])) {
+        // "<ip> - <isp>, <country>", with an optional " (<distance>)" suffix.
+        $s = preg_replace('/\s*\([^)]*\)\s*$/', '', $decoded['processedString']);
+        $comma = strrpos($s, ',');
+        if (false !== $comma) {
+            $country = trim(substr($s, $comma + 1));
+            if ('' !== $country) {
+                return statsSafeName($country);
+            }
+        }
+    }
+
+    return 'Unknown';
+}
+
+/**
+ * Folds groups below the privacy threshold into a single "Other" entry.
+ *
+ * @param array $groups   name => ['tests' => int, ...]
+ * @param int   $threshold
+ *
+ * @return array
+ */
+function statsApplyThreshold(array $groups, $threshold)
+{
+    $kept = [];
+    $foldedTests = 0;
+    $foldedGroups = 0;
+
+    foreach ($groups as $name => $group) {
+        if ($group['tests'] >= $threshold) {
+            $kept[$name] = $group;
+        } else {
+            $foldedTests += $group['tests'];
+            ++$foldedGroups;
+        }
+    }
+
+    if ($foldedTests >= $threshold) {
+        $kept['Other'] = ['tests' => $foldedTests, 'groups' => $foldedGroups];
+    }
+
+    return $kept;
+}
+
+/**
+ * Builds the summary for a half-open period.
+ *
+ * @param string $from inclusive, "YYYY-MM-DD HH:MM:SS"
+ * @param string $to   exclusive
+ *
+ * @return array|false
+ */
+function statsBuildSummary($from, $to)
+{
+    $stmt = getSpeedtestUsersBetween($from, $to);
+    if (!($stmt instanceof PDOStatement)) {
+        return false;
+    }
+
+    $overall = [
+        'download' => statsNewSeries(),
+        'upload' => statsNewSeries(),
+        'ping' => statsNewSeries(),
+        'jitter' => statsNewSeries(),
+    ];
+    $tests = 0;
+    $malformed = 0;
+    $clients = [];
+    $families = [];
+    $countries = [];
+
+    while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+        ++$tests;
+
+        $dl = normalizeMeasurement($row['dl']);
+        $ul = normalizeMeasurement($row['ul']);
+        $ping = normalizeMeasurement($row['ping']);
+        $jitter = normalizeMeasurement($row['jitter']);
+
+        if (null === $dl) {
+            ++$malformed;
+        }
+
+        statsAdd($overall['download'], $dl, STATS_SPEED_BUCKET);
+        statsAdd($overall['upload'], $ul, STATS_SPEED_BUCKET);
+        statsAdd($overall['ping'], $ping, STATS_LATENCY_BUCKET);
+        statsAdd($overall['jitter'], $jitter, STATS_LATENCY_BUCKET);
+
+        $client = statsClassifyClient($row['ua']);
+        $family = statsAddressFamily($row['ip']);
+        $country = statsCountry($row['ispinfo']);
+
+        if (!isset($clients[$client])) {
+            $clients[$client] = [
+                'tests' => 0,
+                'download' => statsNewSeries(),
+                'upload' => statsNewSeries(),
+                'families' => [],
+            ];
+        }
+        ++$clients[$client]['tests'];
+        statsAdd($clients[$client]['download'], $dl, STATS_SPEED_BUCKET);
+        statsAdd($clients[$client]['upload'], $ul, STATS_SPEED_BUCKET);
+        if (!isset($clients[$client]['families'][$family])) {
+            $clients[$client]['families'][$family] = 0;
+        }
+        ++$clients[$client]['families'][$family];
+
+        if (!isset($families[$family])) {
+            $families[$family] = ['tests' => 0, 'download' => statsNewSeries()];
+        }
+        ++$families[$family]['tests'];
+        statsAdd($families[$family]['download'], $dl, STATS_SPEED_BUCKET);
+
+        if (!isset($countries[$country])) {
+            $countries[$country] = [
+                'tests' => 0,
+                'download' => statsNewSeries(),
+                'upload' => statsNewSeries(),
+                'ipv6' => 0,
+            ];
+        }
+        ++$countries[$country]['tests'];
+        statsAdd($countries[$country]['download'], $dl, STATS_SPEED_BUCKET);
+        statsAdd($countries[$country]['upload'], $ul, STATS_SPEED_BUCKET);
+        if ('IPv6' === $family) {
+            ++$countries[$country]['ipv6'];
+        }
+    }
+
+    $summary = [
+        'from' => $from,
+        'to' => $to,
+        'generated' => gmdate('Y-m-d H:i:s').' UTC',
+        'threshold' => STATS_PRIVACY_THRESHOLD,
+        'speed_resolution' => STATS_SPEED_BUCKET,
+        'latency_resolution' => STATS_LATENCY_BUCKET,
+        'tests' => $tests,
+        'malformed' => $malformed,
+        'download' => statsSummarise($overall['download'], STATS_SPEED_BUCKET),
+        'upload' => statsSummarise($overall['upload'], STATS_SPEED_BUCKET),
+        'ping' => statsSummarise($overall['ping'], STATS_LATENCY_BUCKET),
+        'jitter' => statsSummarise($overall['jitter'], STATS_LATENCY_BUCKET),
+    ];
+
+    $reduced = [];
+    foreach ($clients as $name => $client) {
+        $reduced[$name] = [
+            'tests' => $client['tests'],
+            'download' => statsSummarise($client['download'], STATS_SPEED_BUCKET),
+            'upload' => statsSummarise($client['upload'], STATS_SPEED_BUCKET),
+            'families' => $client['families'],
+        ];
+    }
+    $summary['clients'] = statsApplyThreshold($reduced, STATS_PRIVACY_THRESHOLD);
+
+    $reduced = [];
+    foreach ($families as $name => $family) {
+        $reduced[$name] = [
+            'tests' => $family['tests'],
+            'download' => statsSummarise($family['download'], STATS_SPEED_BUCKET),
+        ];
+    }
+    $summary['families'] = statsApplyThreshold($reduced, STATS_PRIVACY_THRESHOLD);
+
+    $reduced = [];
+    foreach ($countries as $name => $country) {
+        $reduced[$name] = [
+            'tests' => $country['tests'],
+            'download' => statsSummarise($country['download'], STATS_SPEED_BUCKET),
+            'upload' => statsSummarise($country['upload'], STATS_SPEED_BUCKET),
+            'ipv6_share' => $country['tests'] > 0 ? $country['ipv6'] / $country['tests'] : 0.0,
+        ];
+    }
+    uasort($reduced, function ($a, $b) {
+        return $b['tests'] - $a['tests'];
+    });
+    $summary['countries'] = statsApplyThreshold($reduced, STATS_PRIVACY_THRESHOLD);
+
+    return $summary;
+}
+
+/**
+ * The bounds of a calendar month, as the database stores them.
+ *
+ * @param string $month "YYYY-MM"
+ *
+ * @return array{0: string, 1: string}|null
+ */
+function statsMonthBounds($month)
+{
+    if (!preg_match('/^(\d{4})-(\d{2})$/', (string) $month, $m)) {
+        return null;
+    }
+
+    $year = (int) $m[1];
+    $mon = (int) $m[2];
+    if ($mon < 1 || $mon > 12) {
+        return null;
+    }
+
+    $from = sprintf('%04d-%02d-01 00:00:00', $year, $mon);
+    $nextYear = 12 === $mon ? $year + 1 : $year;
+    $nextMon = 12 === $mon ? 1 : $mon + 1;
+    $to = sprintf('%04d-%02d-01 00:00:00', $nextYear, $nextMon);
+
+    return [$from, $to];
+}
+
+/**
+ * Where cached summaries are written.
+ *
+ * @return string
+ */
+function statsCacheDir()
+{
+    require TELEMETRY_SETTINGS_FILE;
+
+    if (isset($stats_cache_dir) && '' !== $stats_cache_dir) {
+        return rtrim($stats_cache_dir, '/');
+    }
+
+    // Keyed by installation, so two deployments sharing a temporary directory
+    // cannot land on the same path, and so a directory left behind by another
+    // user cannot be written into.
+    return rtrim(sys_get_temp_dir(), '/').'/librespeed-stats-'.substr(sha1(__DIR__), 0, 12);
+}
+
+/**
+ * The month the database considers current, falling back to this machine's
+ * clock if it cannot be asked.
+ *
+ * @return string "YYYY-MM"
+ */
+function statsCurrentMonth()
+{
+    $now = getDatabaseNow();
+    if (null !== $now && preg_match('/^(\d{4})-(\d{2})/', $now, $m)) {
+        return $m[1].'-'.$m[2];
+    }
+
+    return gmdate('Y-m');
+}
+
+/**
+ * The month before the current one.
+ *
+ * @return string "YYYY-MM"
+ */
+function statsPreviousMonth()
+{
+    $current = statsCurrentMonth();
+
+    return gmdate('Y-m', strtotime($current.'-01 12:00:00 -1 month'));
+}
+
+/**
+ * Returns a month's summary, computing it only when the cache is missing or
+ * older than the month it describes still being open.
+ *
+ * A finished month never changes, so its cache never expires. The current month
+ * is recomputed at most once every $maxAge seconds, which is what stops a page
+ * view from turning into a table scan.
+ *
+ * @param string $month "YYYY-MM"
+ * @param int    $maxAge
+ * @param bool   $build whether a stale cache may be regenerated here
+ *
+ * @return array|null
+ */
+function statsMonthlySummary($month, $maxAge = 3600, $build = true)
+{
+    $bounds = statsMonthBounds($month);
+    if (null === $bounds) {
+        return null;
+    }
+
+    $dir = statsCacheDir();
+    $file = $dir.'/'.$month.'.json';
+    $isCurrent = $month === statsCurrentMonth();
+
+    if (is_readable($file)) {
+        $age = time() - (int) filemtime($file);
+        if (!$isCurrent || $age < $maxAge) {
+            $cached = json_decode((string) file_get_contents($file), true);
+            if (is_array($cached)) {
+                return $cached;
+            }
+        }
+    }
+
+    if (!$build) {
+        return null;
+    }
+
+    $summary = statsBuildSummary($bounds[0], $bounds[1]);
+    if (false === $summary) {
+        return null;
+    }
+
+    if (!is_dir($dir)) {
+        @mkdir($dir, 0770, true);
+    }
+    $encoded = json_encode($summary);
+    if (false !== $encoded && is_dir($dir) && is_writable($dir)) {
+        // Written through a temporary file so a reader never sees half of it,
+        // and only promoted once the whole of it is on disk. A short write left
+        // in place would be read back as an unusable cache, and every request
+        // would then scan the month again -- the one outcome this file exists
+        // to prevent.
+        $tmp = $file.'.'.getmypid().'.tmp';
+        if (strlen($encoded) === @file_put_contents($tmp, $encoded)) {
+            @rename($tmp, $file);
+        } else {
+            @unlink($tmp);
+        }
+    }
+
+    return $summary;
+}

--- a/results/stats_summary.php
+++ b/results/stats_summary.php
@@ -1,0 +1,570 @@
+<?php
+
+/**
+ * Aggregate telemetry statistics.
+ *
+ * This computes a summary of a period once and caches it, rather than querying
+ * on every page view. That is what makes a public report safe to expose: the
+ * page reads a handful of numbers from a file, so the cost of serving it does
+ * not grow with the size of the table and cannot be used to make the database
+ * do work on demand.
+ *
+ * Everything is derived in PHP rather than in SQL. Medians and percentiles have
+ * no portable spelling across the four supported backends — PostgreSQL and
+ * MSSQL have percentile_cont, MySQL needs window functions, SQLite has neither
+ * — and the measurement columns are declared `text` everywhere, so aggregating
+ * them in SQL means either a cast that a single malformed row can abort or a
+ * silent string comparison that answers the wrong question.
+ */
+
+require_once __DIR__.'/telemetry_db.php';
+
+/**
+ * Groups smaller than this are not reported on their own.
+ *
+ * A country line covering three tests is close to naming a person, so anything
+ * below the threshold is folded into a single "Other" row, and that row is
+ * itself dropped unless it clears the threshold too.
+ *
+ * This hides how the small groups are made up, not that they exist: with the
+ * total shown, their combined size is still the total minus the visible rows,
+ * and where only one group was withheld that is its exact size. What it does
+ * prevent is reporting a measurement for a group too small to report one for.
+ */
+const STATS_PRIVACY_THRESHOLD = 100;
+
+/** Percentiles are resolved to this many Mbit/s. */
+const STATS_SPEED_BUCKET = 1.0;
+
+/** ...and this many milliseconds. */
+const STATS_LATENCY_BUCKET = 0.1;
+
+/**
+ * A running total plus a sparse histogram.
+ *
+ * The histogram is what keeps this usable on a shared host: holding every
+ * measurement to sort it would cost hundreds of megabytes on a busy instance,
+ * while counting into buckets is bounded by the number of distinct buckets, so
+ * a million tests collapse into a few thousand integers. The mean is summed
+ * exactly; only the percentiles carry the bucket's resolution.
+ *
+ * @return array
+ */
+function statsNewSeries()
+{
+    return ['n' => 0, 'sum' => 0.0, 'hist' => []];
+}
+
+/**
+ * @param array      $series
+ * @param float|null $value
+ * @param float      $bucket
+ *
+ * @return void
+ */
+function statsAdd(array &$series, $value, $bucket)
+{
+    if (null === $value) {
+        return;
+    }
+
+    ++$series['n'];
+    $series['sum'] += $value;
+
+    $index = (int) floor($value / $bucket);
+    if (isset($series['hist'][$index])) {
+        ++$series['hist'][$index];
+    } else {
+        $series['hist'][$index] = 1;
+    }
+}
+
+/**
+ * Reduces a series to the figures that get reported.
+ *
+ * @param array $series
+ * @param float $bucket
+ * @param int[] $percentiles
+ *
+ * @return array|null
+ */
+function statsSummarise(array $series, $bucket, array $percentiles = [10, 25, 50, 75, 90])
+{
+    if (0 === $series['n']) {
+        return null;
+    }
+
+    $out = [
+        'tests' => $series['n'],
+        'mean' => $series['sum'] / $series['n'],
+    ];
+
+    $hist = $series['hist'];
+    ksort($hist);
+
+    foreach ($percentiles as $p) {
+        // Nearest-rank: the smallest bucket whose cumulative count reaches the
+        // requested share. Interpolating would suggest a precision the bucket
+        // width does not have.
+        $target = $p / 100 * $series['n'];
+        $seen = 0;
+        $value = 0.0;
+        foreach ($hist as $index => $count) {
+            $seen += $count;
+            if ($seen >= $target) {
+                $value = $index * $bucket;
+
+                break;
+            }
+        }
+        $out['p'.$p] = $value;
+    }
+
+    return $out;
+}
+
+/**
+ * Keeps a group name to text that can be encoded.
+ *
+ * Client and ISP strings are stored exactly as they arrived, so a group name
+ * derived from one can hold any byte sequence. json_encode() refuses invalid
+ * UTF-8 outright, which would leave the summary uncacheable, so anything that
+ * is not valid is reported as unknown rather than carried through.
+ *
+ * @param string $name
+ *
+ * @return string
+ */
+function statsSafeName($name)
+{
+    // //u makes the match fail on invalid UTF-8, which is the cheapest way to
+    // test a string for it.
+    return preg_match('//u', $name) ? $name : 'Unknown';
+}
+
+/**
+ * Names the kind of client a user agent belongs to.
+ *
+ * Deliberately coarse. The user agent is chosen by whoever sends it, so this is
+ * a description of what clients claim to be, not a measurement; a handful of
+ * buckets can be read that way honestly, while a long tail of exact strings
+ * invites treating it as fact. The raw value is never reported.
+ *
+ * @param string $ua
+ *
+ * @return string
+ */
+function statsClassifyClient($ua)
+{
+    $ua = trim((string) $ua);
+    if ('' === $ua) {
+        return 'Unknown';
+    }
+
+    // The Rust port installs under the same binary name as the Go client, so
+    // the longer prefix has to be tested first.
+    if (0 === stripos($ua, 'librespeed-cli-rust/')) {
+        return 'LibreSpeed CLI (Rust)';
+    }
+    if (0 === stripos($ua, 'librespeed-cli/')) {
+        return 'LibreSpeed CLI (Go)';
+    }
+    if (false !== stripos($ua, 'Dalvik') || false !== stripos($ua, 'okhttp')) {
+        return 'Android app';
+    }
+    if (0 === stripos($ua, 'Mozilla/')) {
+        return 'Web browser';
+    }
+
+    return 'Other';
+}
+
+/**
+ * Names the address family without disclosing the address.
+ *
+ * @param string $ip
+ *
+ * @return string
+ */
+function statsAddressFamily($ip)
+{
+    $ip = trim((string) $ip);
+    if ('' === $ip || '0.0.0.0' === $ip) {
+        // What a deployment with redact_ip_addresses stores. Reporting it as
+        // IPv4 would invent a fact.
+        return 'Unknown';
+    }
+
+    return false === strpos($ip, ':') ? 'IPv4' : 'IPv6';
+}
+
+/**
+ * Digs the country out of the stored ISP information.
+ *
+ * There is no country column: the API path leaves it in rawIspInfo, and the
+ * offline database path only glues it onto the end of processedString.
+ *
+ * @param string $ispinfo
+ *
+ * @return string
+ */
+function statsCountry($ispinfo)
+{
+    $decoded = json_decode((string) $ispinfo, true);
+    if (!is_array($decoded)) {
+        return 'Unknown';
+    }
+
+    if (isset($decoded['rawIspInfo']['country']) && is_string($decoded['rawIspInfo']['country'])) {
+        $country = trim($decoded['rawIspInfo']['country']);
+        if ('' !== $country) {
+            return statsSafeName($country);
+        }
+    }
+
+    if (isset($decoded['processedString']) && is_string($decoded['processedString'])) {
+        // "<ip> - <isp>, <country>", with an optional " (<distance>)" suffix.
+        $s = preg_replace('/\s*\([^)]*\)\s*$/', '', $decoded['processedString']);
+        $comma = strrpos($s, ',');
+        if (false !== $comma) {
+            $country = trim(substr($s, $comma + 1));
+            if ('' !== $country) {
+                return statsSafeName($country);
+            }
+        }
+    }
+
+    return 'Unknown';
+}
+
+/**
+ * Folds groups below the privacy threshold into a single "Other" entry.
+ *
+ * @param array $groups   name => ['tests' => int, ...]
+ * @param int   $threshold
+ *
+ * @return array
+ */
+/**
+ * Orders a group by test count, and by name where counts tie.
+ *
+ * The rows arrive in whatever order the database happened to return them --
+ * no query here pins that down -- so without this a rebuilt summary reshuffles
+ * although not a single number changed, and two servers reporting the same
+ * month disagree on the order of their tables.
+ *
+ * @return array
+ */
+function statsSortByTests(array $rows)
+{
+    uksort($rows, function ($a, $b) use ($rows) {
+        $byTests = $rows[$b]['tests'] - $rows[$a]['tests'];
+
+        return 0 !== $byTests ? $byTests : strcmp((string) $a, (string) $b);
+    });
+
+    return $rows;
+}
+
+function statsApplyThreshold(array $groups, $threshold)
+{
+    $kept = [];
+    $foldedTests = 0;
+    $foldedGroups = 0;
+
+    foreach ($groups as $name => $group) {
+        if ($group['tests'] >= $threshold) {
+            $kept[$name] = $group;
+        } else {
+            $foldedTests += $group['tests'];
+            ++$foldedGroups;
+        }
+    }
+
+    if ($foldedTests >= $threshold) {
+        $kept['Other'] = ['tests' => $foldedTests, 'groups' => $foldedGroups];
+    }
+
+    return $kept;
+}
+
+/**
+ * Builds the summary for a half-open period.
+ *
+ * @param string $from inclusive, "YYYY-MM-DD HH:MM:SS"
+ * @param string $to   exclusive
+ *
+ * @return array|false
+ */
+function statsBuildSummary($from, $to)
+{
+    $stmt = getSpeedtestUsersBetween($from, $to);
+    if (!($stmt instanceof PDOStatement)) {
+        return false;
+    }
+
+    $overall = [
+        'download' => statsNewSeries(),
+        'upload' => statsNewSeries(),
+        'ping' => statsNewSeries(),
+        'jitter' => statsNewSeries(),
+    ];
+    $tests = 0;
+    $malformed = 0;
+    $clients = [];
+    $families = [];
+    $countries = [];
+
+    while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+        ++$tests;
+
+        $dl = normalizeMeasurement($row['dl']);
+        $ul = normalizeMeasurement($row['ul']);
+        $ping = normalizeMeasurement($row['ping']);
+        $jitter = normalizeMeasurement($row['jitter']);
+
+        if (null === $dl) {
+            ++$malformed;
+        }
+
+        statsAdd($overall['download'], $dl, STATS_SPEED_BUCKET);
+        statsAdd($overall['upload'], $ul, STATS_SPEED_BUCKET);
+        statsAdd($overall['ping'], $ping, STATS_LATENCY_BUCKET);
+        statsAdd($overall['jitter'], $jitter, STATS_LATENCY_BUCKET);
+
+        $client = statsClassifyClient($row['ua']);
+        $family = statsAddressFamily($row['ip']);
+        $country = statsCountry($row['ispinfo']);
+
+        if (!isset($clients[$client])) {
+            $clients[$client] = [
+                'tests' => 0,
+                'download' => statsNewSeries(),
+                'upload' => statsNewSeries(),
+                'families' => [],
+            ];
+        }
+        ++$clients[$client]['tests'];
+        statsAdd($clients[$client]['download'], $dl, STATS_SPEED_BUCKET);
+        statsAdd($clients[$client]['upload'], $ul, STATS_SPEED_BUCKET);
+        if (!isset($clients[$client]['families'][$family])) {
+            $clients[$client]['families'][$family] = 0;
+        }
+        ++$clients[$client]['families'][$family];
+
+        if (!isset($families[$family])) {
+            $families[$family] = ['tests' => 0, 'download' => statsNewSeries()];
+        }
+        ++$families[$family]['tests'];
+        statsAdd($families[$family]['download'], $dl, STATS_SPEED_BUCKET);
+
+        if (!isset($countries[$country])) {
+            $countries[$country] = [
+                'tests' => 0,
+                'download' => statsNewSeries(),
+                'upload' => statsNewSeries(),
+                'ipv6' => 0,
+            ];
+        }
+        ++$countries[$country]['tests'];
+        statsAdd($countries[$country]['download'], $dl, STATS_SPEED_BUCKET);
+        statsAdd($countries[$country]['upload'], $ul, STATS_SPEED_BUCKET);
+        if ('IPv6' === $family) {
+            ++$countries[$country]['ipv6'];
+        }
+    }
+
+    $summary = [
+        'from' => $from,
+        'to' => $to,
+        'generated' => gmdate('Y-m-d H:i:s').' UTC',
+        'threshold' => STATS_PRIVACY_THRESHOLD,
+        'speed_resolution' => STATS_SPEED_BUCKET,
+        'latency_resolution' => STATS_LATENCY_BUCKET,
+        'tests' => $tests,
+        'malformed' => $malformed,
+        'download' => statsSummarise($overall['download'], STATS_SPEED_BUCKET),
+        'upload' => statsSummarise($overall['upload'], STATS_SPEED_BUCKET),
+        'ping' => statsSummarise($overall['ping'], STATS_LATENCY_BUCKET),
+        'jitter' => statsSummarise($overall['jitter'], STATS_LATENCY_BUCKET),
+    ];
+
+    $reduced = [];
+    foreach ($clients as $name => $client) {
+        $reduced[$name] = [
+            'tests' => $client['tests'],
+            'download' => statsSummarise($client['download'], STATS_SPEED_BUCKET),
+            'upload' => statsSummarise($client['upload'], STATS_SPEED_BUCKET),
+            'families' => $client['families'],
+        ];
+    }
+    $summary['clients'] = statsApplyThreshold(statsSortByTests($reduced), STATS_PRIVACY_THRESHOLD);
+
+    $reduced = [];
+    foreach ($families as $name => $family) {
+        $reduced[$name] = [
+            'tests' => $family['tests'],
+            'download' => statsSummarise($family['download'], STATS_SPEED_BUCKET),
+        ];
+    }
+    $summary['families'] = statsApplyThreshold(statsSortByTests($reduced), STATS_PRIVACY_THRESHOLD);
+
+    $reduced = [];
+    foreach ($countries as $name => $country) {
+        $reduced[$name] = [
+            'tests' => $country['tests'],
+            'download' => statsSummarise($country['download'], STATS_SPEED_BUCKET),
+            'upload' => statsSummarise($country['upload'], STATS_SPEED_BUCKET),
+            'ipv6_share' => $country['tests'] > 0 ? $country['ipv6'] / $country['tests'] : 0.0,
+        ];
+    }
+    $summary['countries'] = statsApplyThreshold(statsSortByTests($reduced), STATS_PRIVACY_THRESHOLD);
+
+    return $summary;
+}
+
+/**
+ * The bounds of a calendar month, as the database stores them.
+ *
+ * @param string $month "YYYY-MM"
+ *
+ * @return array{0: string, 1: string}|null
+ */
+function statsMonthBounds($month)
+{
+    if (!preg_match('/^(\d{4})-(\d{2})$/', (string) $month, $m)) {
+        return null;
+    }
+
+    $year = (int) $m[1];
+    $mon = (int) $m[2];
+    if ($mon < 1 || $mon > 12) {
+        return null;
+    }
+
+    $from = sprintf('%04d-%02d-01 00:00:00', $year, $mon);
+    $nextYear = 12 === $mon ? $year + 1 : $year;
+    $nextMon = 12 === $mon ? 1 : $mon + 1;
+    $to = sprintf('%04d-%02d-01 00:00:00', $nextYear, $nextMon);
+
+    return [$from, $to];
+}
+
+/**
+ * Where cached summaries are written.
+ *
+ * @return string
+ */
+function statsCacheDir()
+{
+    require TELEMETRY_SETTINGS_FILE;
+
+    if (isset($stats_cache_dir) && '' !== $stats_cache_dir) {
+        return rtrim($stats_cache_dir, '/');
+    }
+
+    // Keyed by installation, so two deployments sharing a temporary directory
+    // cannot land on the same path.
+    return rtrim(sys_get_temp_dir(), '/').'/librespeed-stats-'.substr(sha1(__DIR__), 0, 12);
+}
+
+/**
+ * The month the database considers current, falling back to this machine's
+ * clock if it cannot be asked.
+ *
+ * @return string "YYYY-MM"
+ */
+function statsCurrentMonth()
+{
+    $now = getDatabaseNow();
+    if (null !== $now && preg_match('/^(\d{4})-(\d{2})/', $now, $m)) {
+        return $m[1].'-'.$m[2];
+    }
+
+    return gmdate('Y-m');
+}
+
+/**
+ * The month before the current one.
+ *
+ * @return string "YYYY-MM"
+ */
+function statsPreviousMonth()
+{
+    $current = statsCurrentMonth();
+
+    return gmdate('Y-m', strtotime($current.'-01 12:00:00 -1 month'));
+}
+
+/**
+ * Returns a month's summary, computing it only when the cache is missing or
+ * older than the month it describes still being open.
+ *
+ * A finished month never changes, so its cache never expires. The current month
+ * is recomputed at most once every $maxAge seconds, which is what stops a page
+ * view from turning into a table scan.
+ *
+ * @param string $month "YYYY-MM"
+ * @param int    $maxAge
+ * @param bool   $build whether a stale cache may be regenerated here
+ *
+ * @return array|null
+ */
+function statsMonthlySummary($month, $maxAge = 3600, $build = true)
+{
+    $bounds = statsMonthBounds($month);
+    if (null === $bounds) {
+        return null;
+    }
+
+    $dir = statsCacheDir();
+    $file = $dir.'/'.$month.'.json';
+    $isCurrent = $month === statsCurrentMonth();
+
+    if (is_readable($file)) {
+        $age = time() - (int) filemtime($file);
+        if (!$isCurrent || $age < $maxAge) {
+            $cached = json_decode((string) file_get_contents($file), true);
+            if (is_array($cached)) {
+                return $cached;
+            }
+        }
+    }
+
+    if (!$build) {
+        return null;
+    }
+
+    $summary = statsBuildSummary($bounds[0], $bounds[1]);
+    if (false === $summary) {
+        return null;
+    }
+
+    // The default location is inside a world-writable temporary directory, so
+    // another local user can get there first. A symlink left at that path would
+    // redirect every write that follows, and a group-writable directory would
+    // let its contents be replaced, so refuse the first and do not create the
+    // second.
+    if (is_link($dir)) {
+        return $summary;
+    }
+    if (!is_dir($dir)) {
+        @mkdir($dir, 0700, true);
+    }
+    $encoded = json_encode($summary);
+    if (false !== $encoded && is_dir($dir) && is_writable($dir)) {
+        // Written through a temporary file so a reader never sees half of it,
+        // and only promoted once the whole of it is on disk. A short write left
+        // in place would be read back as an unusable cache, and every request
+        // would then scan the month again -- the one outcome this file exists
+        // to prevent.
+        $tmp = $file.'.'.getmypid().'.tmp';
+        if (strlen($encoded) === @file_put_contents($tmp, $encoded)) {
+            @rename($tmp, $file);
+        } else {
+            @unlink($tmp);
+        }
+    }
+
+    return $summary;
+}

--- a/results/telemetry_db.php
+++ b/results/telemetry_db.php
@@ -138,6 +138,10 @@ function getPdo($returnErrorMessage = false)
                 `log`       longtext
                 );
             ');
+            // Every query that is not a lookup by id orders or filters by
+            // timestamp, and without this the table is scanned in full each
+            // time. The other schemas declare the same index.
+            $pdo->exec('CREATE INDEX IF NOT EXISTS `speedtest_users_timestamp` ON `speedtest_users` (`timestamp`);');
 
             return $pdo;
         }

--- a/results/telemetry_db.php
+++ b/results/telemetry_db.php
@@ -326,6 +326,74 @@ function getSpeedtestUserById($id,$returnExceptionOnError = false)
 }
 
 /**
+ * The database's own idea of the current time.
+ *
+ * Which month a row belongs to is decided by comparing against the timestamp
+ * column, so it always comes out consistent with whatever the column holds. But
+ * deciding which month is the current one cannot be done from PHP's clock: the
+ * backends disagree on what they record. SQLite's CURRENT_TIMESTAMP is UTC,
+ * PostgreSQL's now() and MSSQL's getdate() are the server's local time, and
+ * MySQL's depends on the session time zone. Asking the database keeps that
+ * decision in the same frame as the data.
+ *
+ * @return string|null "YYYY-MM-DD HH:MM:SS"
+ */
+function getDatabaseNow()
+{
+    $pdo = getPdo();
+    if (!($pdo instanceof PDO)) {
+        return null;
+    }
+
+    try {
+        // ANSI, and accepted by all four supported backends.
+        $stmt = $pdo->query('SELECT CURRENT_TIMESTAMP');
+        $value = $stmt->fetchColumn();
+        if (!is_string($value) || '' === $value) {
+            return null;
+        }
+
+        return $value;
+    } catch (Exception $e) {
+        return null;
+    }
+}
+
+/**
+ * Streams the rows of a half-open period for aggregation.
+ *
+ * Returns the statement rather than an array: a month of a busy instance is
+ * more rows than should be materialised at once, and the caller only needs to
+ * pass over them. Only the columns the summary reads are selected — the log is
+ * the largest column in the table and nothing aggregates it.
+ *
+ * @param string $from inclusive
+ * @param string $to   exclusive
+ *
+ * @return PDOStatement|false
+ */
+function getSpeedtestUsersBetween($from, $to)
+{
+    $pdo = getPdo();
+    if (!($pdo instanceof PDO)) {
+        return false;
+    }
+
+    try {
+        $stmt = $pdo->prepare(
+            'SELECT timestamp, ip, ispinfo, ua, dl, ul, ping, jitter
+            FROM speedtest_users
+            WHERE timestamp >= ? AND timestamp < ?'
+        );
+        $stmt->execute([$from, $to]);
+
+        return $stmt;
+    } catch (Exception $e) {
+        return false;
+    }
+}
+
+/**
  * @return array|false
  */
 function getLatestSpeedtestUsers()

--- a/results/telemetry_db.php
+++ b/results/telemetry_db.php
@@ -189,8 +189,54 @@ function isObfuscationEnabled()
 /**
  * @return string|false returns the id of the inserted column or false on error if returnErrorMessage is false or a error message if returnErrorMessage is true
  */
+/**
+ * Normalises a measurement into a number, or null when it is not one.
+ *
+ * The four measurement columns are declared `text` in every schema shipped
+ * here, and nothing validated what went into them, so a client could store any
+ * string it liked. That has consequences beyond statistics: `format()` in
+ * index.php hands the value to `number_format()`, which on PHP 8 raises a
+ * TypeError for a string, so a single empty `dl=` turned that result's share
+ * image into a 500.
+ *
+ * Storing null instead keeps the row — the test still happened, and the IP,
+ * user agent and timestamp are still worth having — while leaving the value out
+ * of aggregates, which skip nulls. `COUNT(*) - COUNT(dl)` then reports how many
+ * submissions arrived malformed, so nothing is hidden by accepting them.
+ *
+ * No upper bound is imposed: links keep getting faster, and a cap would
+ * silently discard the fastest real results.
+ *
+ * @param mixed $value
+ *
+ * @return float|null
+ */
+function normalizeMeasurement($value)
+{
+    if (is_array($value) || is_object($value) || is_bool($value) || null === $value) {
+        return null;
+    }
+
+    $value = trim((string) $value);
+    if ('' === $value || !is_numeric($value)) {
+        return null;
+    }
+
+    $number = (float) $value;
+    if (!is_finite($number) || $number < 0) {
+        return null;
+    }
+
+    return $number;
+}
+
 function insertSpeedtestUser($ip, $ispinfo, $extra, $ua, $lang, $dl, $ul, $ping, $jitter, $log, $returnExceptionOnError = false)
 {
+    $dl = normalizeMeasurement($dl);
+    $ul = normalizeMeasurement($ul);
+    $ping = normalizeMeasurement($ping);
+    $jitter = normalizeMeasurement($jitter);
+
     $pdo = getPdo();
     if (!($pdo instanceof PDO)) {
 		if($returnExceptionOnError){

--- a/results/telemetry_db.php
+++ b/results/telemetry_db.php
@@ -187,10 +187,56 @@ function isObfuscationEnabled()
 }
 
 /**
+ * Normalises a measurement into a number, or null when it is not one.
+ *
+ * The four measurement columns are declared `text` in every schema shipped
+ * here, and nothing validated what went into them, so a client could store any
+ * string it liked. That has consequences beyond statistics: `format()` in
+ * index.php hands the value to `number_format()`, which on PHP 8 raises a
+ * TypeError for a string, so a single empty `dl=` turned that result's share
+ * image into a 500.
+ *
+ * Storing null instead keeps the row — the test still happened, and the IP,
+ * user agent and timestamp are still worth having — while leaving the value out
+ * of aggregates, which skip nulls. `COUNT(*) - COUNT(dl)` then reports how many
+ * submissions arrived malformed, so nothing is hidden by accepting them.
+ *
+ * No upper bound is imposed: links keep getting faster, and a cap would
+ * silently discard the fastest real results.
+ *
+ * @param mixed $value
+ *
+ * @return float|null
+ */
+function normalizeMeasurement($value)
+{
+    if (is_array($value) || is_object($value) || is_bool($value) || null === $value) {
+        return null;
+    }
+
+    $value = trim((string) $value);
+    if ('' === $value || !is_numeric($value)) {
+        return null;
+    }
+
+    $number = (float) $value;
+    if (!is_finite($number) || $number < 0) {
+        return null;
+    }
+
+    return $number;
+}
+
+/**
  * @return string|false returns the id of the inserted column or false on error if returnErrorMessage is false or a error message if returnErrorMessage is true
  */
 function insertSpeedtestUser($ip, $ispinfo, $extra, $ua, $lang, $dl, $ul, $ping, $jitter, $log, $returnExceptionOnError = false)
 {
+    $dl = normalizeMeasurement($dl);
+    $ul = normalizeMeasurement($ul);
+    $ping = normalizeMeasurement($ping);
+    $jitter = normalizeMeasurement($jitter);
+
     $pdo = getPdo();
     if (!($pdo instanceof PDO)) {
 		if($returnExceptionOnError){

--- a/results/telemetry_mssql.sql
+++ b/results/telemetry_mssql.sql
@@ -33,4 +33,10 @@ GO
 ALTER TABLE [dbo].[speedtest_users] ADD  CONSTRAINT [DF_speedtest_users_timestamp]  DEFAULT (getdate()) FOR [timestamp]
 GO
 
+CREATE NONCLUSTERED INDEX [speedtest_users_timestamp] ON [dbo].[speedtest_users]
+(
+	[timestamp] ASC
+) ON [PRIMARY]
+GO
+
 

--- a/results/telemetry_mysql.sql
+++ b/results/telemetry_mysql.sql
@@ -42,7 +42,8 @@ CREATE TABLE `speedtest_users` (
 -- Indexes for table `speedtest_users`
 --
 ALTER TABLE `speedtest_users`
-  ADD PRIMARY KEY (`id`);
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `speedtest_users_timestamp` (`timestamp`);
 
 --
 -- AUTO_INCREMENT for dumped tables

--- a/results/telemetry_postgresql.sql
+++ b/results/telemetry_postgresql.sql
@@ -108,6 +108,13 @@ ALTER TABLE ONLY speedtest_users
 
 
 --
+-- Name: speedtest_users_timestamp; Type: INDEX; Schema: public; Owner: speedtest
+--
+
+CREATE INDEX speedtest_users_timestamp ON speedtest_users USING btree ("timestamp");
+
+
+--
 -- PostgreSQL database dump complete
 --
 

--- a/results/telemetry_settings.php
+++ b/results/telemetry_settings.php
@@ -8,6 +8,17 @@ $stats_password = 'PASSWORD';
 $enable_id_obfuscation = false;
 // If set to true, IP addresses will be redacted from IP and ISP info fields, as well as the log
 $redact_ip_addresses = false;
+// Name shown on the statistics pages. Leave empty to use the requested hostname.
+// Worth setting: a report is often read as a screenshot, where the address bar is gone.
+$stats_title = '';
+// If set to true, stats_public.php serves a monthly aggregate report without a login.
+// Only totals are published, never individual results: see the privacy threshold in
+// stats_summary.php. Off by default, because publishing anything at all should be a choice.
+$stats_public_report = false;
+// Where computed summaries are cached. A summary is built once per month rather than on
+// each page view, which is what keeps the public report from putting load on the database.
+// Leave empty to use the system temporary directory.
+$stats_cache_dir = '';
 
 // Sqlite3 settings
 $Sqlite_db_file = __DIR__ . '/../../speedtest_telemetry.db';

--- a/tests/telemetry_stats_test.php
+++ b/tests/telemetry_stats_test.php
@@ -1,0 +1,181 @@
+<?php
+
+/**
+ * Tests for the telemetry aggregation helpers.
+ *
+ * Plain PHP on purpose: the repository has no PHP test framework and adding one
+ * for seven functions would cost more than it is worth. Run with
+ *
+ *     php tests/telemetry_stats_test.php
+ *
+ * Exits non-zero on the first failing expectation's suite, and prints what
+ * differed.
+ */
+
+chdir(__DIR__.'/../results');
+require_once __DIR__.'/../results/stats_summary.php';
+
+$failures = 0;
+$checks = 0;
+
+/**
+ * @param mixed  $expected
+ * @param mixed  $actual
+ * @param string $what
+ *
+ * @return void
+ */
+function check($expected, $actual, $what)
+{
+    global $failures, $checks;
+    ++$checks;
+    if ($expected === $actual) {
+        return;
+    }
+    ++$failures;
+    fwrite(STDERR, sprintf(
+        "FAIL %s\n  expected: %s\n  actual:   %s\n",
+        $what,
+        var_export($expected, true),
+        var_export($actual, true)
+    ));
+}
+
+// ---- normalizeMeasurement -------------------------------------------------
+check(312.5, normalizeMeasurement('312.5'), 'a decimal string is a number');
+check(0.0, normalizeMeasurement('0'), 'zero is a measurement, not a missing one');
+check(312.5, normalizeMeasurement(312.5), 'a float passes through');
+check(1.0e3, normalizeMeasurement('1e3'), 'exponent notation is numeric');
+check(42.0, normalizeMeasurement('  42  '), 'surrounding space is trimmed');
+check(null, normalizeMeasurement(''), 'the empty string is not a number');
+check(null, normalizeMeasurement('   '), 'neither is whitespace');
+check(null, normalizeMeasurement('abc'), 'nor a word');
+check(null, normalizeMeasurement('12abc'), 'nor a number with a tail');
+check(null, normalizeMeasurement(null), 'nor a missing field');
+check(null, normalizeMeasurement([]), 'nor an array, which PHP would otherwise cast');
+check(null, normalizeMeasurement(true), 'nor a boolean');
+check(null, normalizeMeasurement('-5'), 'a negative speed is not a measurement');
+check(null, normalizeMeasurement('NaN'), 'NaN is rejected');
+check(null, normalizeMeasurement('INF'), 'so is infinity');
+
+// ---- statsClassifyClient --------------------------------------------------
+check('LibreSpeed CLI (Rust)', statsClassifyClient('librespeed-cli-rust/v0.1.0'), 'the Rust CLI');
+check(
+    'LibreSpeed CLI (Rust)',
+    statsClassifyClient('librespeed-cli-rust/v0.1.0 (linux; powerpc)'),
+    'the Rust CLI naming its platform'
+);
+check('LibreSpeed CLI (Go)', statsClassifyClient('librespeed-cli/1.0.12'), 'the Go CLI');
+check(
+    'LibreSpeed CLI (Go)',
+    statsClassifyClient('librespeed-cli/1.0.12 (linux; arm64)'),
+    'the Go CLI naming its platform'
+);
+check(
+    'Web browser',
+    statsClassifyClient('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/141.0'),
+    'a browser'
+);
+check('Android app', statsClassifyClient('Dalvik/2.1.0 (Linux; U; Android 16)'), 'an Android app');
+check('Android app', statsClassifyClient('okhttp/4.12.0'), 'an okhttp client');
+check('Unknown', statsClassifyClient(''), 'a missing user agent');
+check('Unknown', statsClassifyClient('   '), 'a blank user agent');
+check('Other', statsClassifyClient('curl/8.7.1'), 'anything else');
+
+// ---- statsAddressFamily ---------------------------------------------------
+check('IPv4', statsAddressFamily('198.51.100.7'), 'an IPv4 address');
+check('IPv6', statsAddressFamily('2001:db8::1'), 'an IPv6 address');
+check('Unknown', statsAddressFamily('0.0.0.0'), 'the placeholder redaction stores');
+check('Unknown', statsAddressFamily(''), 'a missing address');
+
+// ---- statsCountry ---------------------------------------------------------
+check(
+    'CZ',
+    statsCountry(json_encode(['rawIspInfo' => ['country' => 'CZ'], 'processedString' => 'x - y, ZZ'])),
+    'the raw field wins over the string'
+);
+check(
+    'Czechia',
+    statsCountry(json_encode(['processedString' => '198.51.100.7 - Example ISP, Czechia'])),
+    'the country is read off the processed string'
+);
+check(
+    'Czechia',
+    statsCountry(json_encode(['processedString' => '198.51.100.7 - Example ISP, Czechia (123.4 km)'])),
+    'a distance suffix is ignored'
+);
+check('Unknown', statsCountry(''), 'no ISP information at all');
+check('Unknown', statsCountry('not json'), 'unparseable ISP information');
+check(
+    'Unknown',
+    statsCountry(json_encode(['processedString' => '198.51.100.7 - Example ISP'])),
+    'an ISP string with no country'
+);
+
+// ---- statsSummarise -------------------------------------------------------
+$series = statsNewSeries();
+foreach (range(1, 100) as $v) {
+    statsAdd($series, (float) $v, 1.0);
+}
+$s = statsSummarise($series, 1.0);
+check(100, $s['tests'], 'every value counted');
+check(50.5, $s['mean'], 'the mean is exact, not bucketed');
+check(10.0, $s['p10'], 'P10 of 1..100');
+check(50.0, $s['p50'], 'P50 of 1..100');
+check(90.0, $s['p90'], 'P90 of 1..100');
+
+$series = statsNewSeries();
+statsAdd($series, null, 1.0);
+check(null, statsSummarise($series, 1.0), 'a series of only nulls reports nothing');
+
+$series = statsNewSeries();
+statsAdd($series, 7.0, 1.0);
+$s = statsSummarise($series, 1.0);
+check(7.0, $s['p50'], 'a single value is its own median');
+check(7.0, $s['mean'], 'and its own mean');
+
+// ---- statsApplyThreshold --------------------------------------------------
+$groups = ['big' => ['tests' => 500], 'small' => ['tests' => 60], 'tiny' => ['tests' => 50]];
+$kept = statsApplyThreshold($groups, 100);
+check(['big', 'Other'], array_keys($kept), 'small groups fold into Other');
+check(110, $kept['Other']['tests'], 'Other carries their combined size');
+check(2, $kept['Other']['groups'], 'and how many were folded');
+
+$kept = statsApplyThreshold(['big' => ['tests' => 500], 'tiny' => ['tests' => 50]], 100);
+check(['big'], array_keys($kept), 'an Other below the threshold is dropped rather than shown');
+
+$kept = statsApplyThreshold([], 100);
+check([], $kept, 'no groups at all');
+
+// ---- statsSafeName --------------------------------------------------------
+check('Czechia', statsSafeName('Czechia'), 'plain ASCII passes');
+check('Česko', statsSafeName('Česko'), 'valid UTF-8 passes');
+check('Unknown', statsSafeName("\xC3\x28"), 'invalid UTF-8 becomes unknown');
+// A group name that json_encode() refuses would leave the whole summary
+// uncacheable, and every request would rebuild it with a full table scan.
+check(
+    'Unknown',
+    statsCountry(json_encode(['rawIspInfo' => ['country' => 'CZ']]) === false ? '' : json_encode(['processedString' => "1.2.3.4 - ISP, \xC3\x28"])),
+    'a country carrying invalid UTF-8 does not reach the summary'
+);
+$encodable = json_encode(['x' => statsSafeName("\xC3\x28")]);
+check(true, false !== $encodable, 'a sanitised name is encodable');
+
+// ---- statsMonthBounds -----------------------------------------------------
+check(
+    ['2026-08-01 00:00:00', '2026-09-01 00:00:00'],
+    statsMonthBounds('2026-08'),
+    'a month in the middle of the year'
+);
+check(
+    ['2026-12-01 00:00:00', '2027-01-01 00:00:00'],
+    statsMonthBounds('2026-12'),
+    'December rolls into the next year'
+);
+check(null, statsMonthBounds('2026-13'), 'a thirteenth month is rejected');
+check(null, statsMonthBounds('2026-00'), 'and a zeroth');
+check(null, statsMonthBounds('not-a-month'), 'and nonsense');
+check(null, statsMonthBounds(''), 'and nothing');
+
+printf("%d checks, %d failures\n", $checks, $failures);
+exit($failures > 0 ? 1 : 0);

--- a/tests/telemetry_stats_test.php
+++ b/tests/telemetry_stats_test.php
@@ -1,0 +1,194 @@
+<?php
+
+/**
+ * Tests for the telemetry aggregation helpers.
+ *
+ * Plain PHP on purpose: the repository has no PHP test framework and adding one
+ * for seven functions would cost more than it is worth. Run with
+ *
+ *     php tests/telemetry_stats_test.php
+ *
+ * Exits non-zero on the first failing expectation's suite, and prints what
+ * differed.
+ */
+
+chdir(__DIR__.'/../results');
+require_once __DIR__.'/../results/stats_summary.php';
+
+$failures = 0;
+$checks = 0;
+
+/**
+ * @param mixed  $expected
+ * @param mixed  $actual
+ * @param string $what
+ *
+ * @return void
+ */
+function check($expected, $actual, $what)
+{
+    global $failures, $checks;
+    ++$checks;
+    if ($expected === $actual) {
+        return;
+    }
+    ++$failures;
+    fwrite(STDERR, sprintf(
+        "FAIL %s\n  expected: %s\n  actual:   %s\n",
+        $what,
+        var_export($expected, true),
+        var_export($actual, true)
+    ));
+}
+
+// ---- normalizeMeasurement -------------------------------------------------
+check(312.5, normalizeMeasurement('312.5'), 'a decimal string is a number');
+check(0.0, normalizeMeasurement('0'), 'zero is a measurement, not a missing one');
+check(312.5, normalizeMeasurement(312.5), 'a float passes through');
+check(1.0e3, normalizeMeasurement('1e3'), 'exponent notation is numeric');
+check(42.0, normalizeMeasurement('  42  '), 'surrounding space is trimmed');
+check(null, normalizeMeasurement(''), 'the empty string is not a number');
+check(null, normalizeMeasurement('   '), 'neither is whitespace');
+check(null, normalizeMeasurement('abc'), 'nor a word');
+check(null, normalizeMeasurement('12abc'), 'nor a number with a tail');
+check(null, normalizeMeasurement(null), 'nor a missing field');
+check(null, normalizeMeasurement([]), 'nor an array, which PHP would otherwise cast');
+check(null, normalizeMeasurement(true), 'nor a boolean');
+check(null, normalizeMeasurement('-5'), 'a negative speed is not a measurement');
+check(null, normalizeMeasurement('NaN'), 'NaN is rejected');
+check(null, normalizeMeasurement('INF'), 'so is infinity');
+
+// ---- statsClassifyClient --------------------------------------------------
+check('LibreSpeed CLI (Rust)', statsClassifyClient('librespeed-cli-rust/v0.1.0'), 'the Rust CLI');
+check(
+    'LibreSpeed CLI (Rust)',
+    statsClassifyClient('librespeed-cli-rust/v0.1.0 (linux; powerpc)'),
+    'the Rust CLI naming its platform'
+);
+check('LibreSpeed CLI (Go)', statsClassifyClient('librespeed-cli/1.0.12'), 'the Go CLI');
+check(
+    'LibreSpeed CLI (Go)',
+    statsClassifyClient('librespeed-cli/1.0.12 (linux; arm64)'),
+    'the Go CLI naming its platform'
+);
+check(
+    'Web browser',
+    statsClassifyClient('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/141.0'),
+    'a browser'
+);
+check('Android app', statsClassifyClient('Dalvik/2.1.0 (Linux; U; Android 16)'), 'an Android app');
+check('Android app', statsClassifyClient('okhttp/4.12.0'), 'an okhttp client');
+check('Unknown', statsClassifyClient(''), 'a missing user agent');
+check('Unknown', statsClassifyClient('   '), 'a blank user agent');
+check('Other', statsClassifyClient('curl/8.7.1'), 'anything else');
+
+// ---- statsAddressFamily ---------------------------------------------------
+check('IPv4', statsAddressFamily('198.51.100.7'), 'an IPv4 address');
+check('IPv6', statsAddressFamily('2001:db8::1'), 'an IPv6 address');
+check('Unknown', statsAddressFamily('0.0.0.0'), 'the placeholder redaction stores');
+check('Unknown', statsAddressFamily(''), 'a missing address');
+
+// ---- statsCountry ---------------------------------------------------------
+check(
+    'CZ',
+    statsCountry(json_encode(['rawIspInfo' => ['country' => 'CZ'], 'processedString' => 'x - y, ZZ'])),
+    'the raw field wins over the string'
+);
+check(
+    'Czechia',
+    statsCountry(json_encode(['processedString' => '198.51.100.7 - Example ISP, Czechia'])),
+    'the country is read off the processed string'
+);
+check(
+    'Czechia',
+    statsCountry(json_encode(['processedString' => '198.51.100.7 - Example ISP, Czechia (123.4 km)'])),
+    'a distance suffix is ignored'
+);
+check('Unknown', statsCountry(''), 'no ISP information at all');
+check('Unknown', statsCountry('not json'), 'unparseable ISP information');
+check(
+    'Unknown',
+    statsCountry(json_encode(['processedString' => '198.51.100.7 - Example ISP'])),
+    'an ISP string with no country'
+);
+
+// ---- statsSummarise -------------------------------------------------------
+$series = statsNewSeries();
+foreach (range(1, 100) as $v) {
+    statsAdd($series, (float) $v, 1.0);
+}
+$s = statsSummarise($series, 1.0);
+check(100, $s['tests'], 'every value counted');
+check(50.5, $s['mean'], 'the mean is exact, not bucketed');
+check(10.0, $s['p10'], 'P10 of 1..100');
+check(50.0, $s['p50'], 'P50 of 1..100');
+check(90.0, $s['p90'], 'P90 of 1..100');
+
+$series = statsNewSeries();
+statsAdd($series, null, 1.0);
+check(null, statsSummarise($series, 1.0), 'a series of only nulls reports nothing');
+
+$series = statsNewSeries();
+statsAdd($series, 7.0, 1.0);
+$s = statsSummarise($series, 1.0);
+check(7.0, $s['p50'], 'a single value is its own median');
+check(7.0, $s['mean'], 'and its own mean');
+
+// ---- statsSortByTests -----------------------------------------------------
+$rows = ['b' => ['tests' => 5], 'a' => ['tests' => 50], 'c' => ['tests' => 5]];
+check(['a', 'b', 'c'], array_keys(statsSortByTests($rows)), 'ordered by test count, then by name');
+// Insertion order follows the database cursor, which no query here pins down,
+// so the same month must sort the same way however the rows arrived.
+$shuffled = ['c' => ['tests' => 5], 'b' => ['tests' => 5], 'a' => ['tests' => 50]];
+check(
+    array_keys(statsSortByTests($rows)),
+    array_keys(statsSortByTests($shuffled)),
+    'the same rows in another order sort the same way'
+);
+check([], statsSortByTests([]), 'no rows at all');
+
+// ---- statsApplyThreshold --------------------------------------------------
+$groups = ['big' => ['tests' => 500], 'small' => ['tests' => 60], 'tiny' => ['tests' => 50]];
+$kept = statsApplyThreshold($groups, 100);
+check(['big', 'Other'], array_keys($kept), 'small groups fold into Other');
+check(110, $kept['Other']['tests'], 'Other carries their combined size');
+check(2, $kept['Other']['groups'], 'and how many were folded');
+
+$kept = statsApplyThreshold(['big' => ['tests' => 500], 'tiny' => ['tests' => 50]], 100);
+check(['big'], array_keys($kept), 'an Other below the threshold is dropped rather than shown');
+
+$kept = statsApplyThreshold([], 100);
+check([], $kept, 'no groups at all');
+
+// ---- statsSafeName --------------------------------------------------------
+check('Czechia', statsSafeName('Czechia'), 'plain ASCII passes');
+check('Česko', statsSafeName('Česko'), 'valid UTF-8 passes');
+check('Unknown', statsSafeName("\xC3\x28"), 'invalid UTF-8 becomes unknown');
+// A group name that json_encode() refuses would leave the whole summary
+// uncacheable, and every request would rebuild it with a full table scan.
+check(
+    'Unknown',
+    statsCountry(json_encode(['rawIspInfo' => ['country' => 'CZ']]) === false ? '' : json_encode(['processedString' => "1.2.3.4 - ISP, \xC3\x28"])),
+    'a country carrying invalid UTF-8 does not reach the summary'
+);
+$encodable = json_encode(['x' => statsSafeName("\xC3\x28")]);
+check(true, false !== $encodable, 'a sanitised name is encodable');
+
+// ---- statsMonthBounds -----------------------------------------------------
+check(
+    ['2026-08-01 00:00:00', '2026-09-01 00:00:00'],
+    statsMonthBounds('2026-08'),
+    'a month in the middle of the year'
+);
+check(
+    ['2026-12-01 00:00:00', '2027-01-01 00:00:00'],
+    statsMonthBounds('2026-12'),
+    'December rolls into the next year'
+);
+check(null, statsMonthBounds('2026-13'), 'a thirteenth month is rejected');
+check(null, statsMonthBounds('2026-00'), 'and a zeroth');
+check(null, statsMonthBounds('not-a-month'), 'and nonsense');
+check(null, statsMonthBounds(''), 'and nothing');
+
+printf("%d checks, %d failures\n", $checks, $failures);
+exit($failures > 0 ? 1 : 0);


### PR DESCRIPTION
`stats.php` shows individual telemetry results, but gives no way to see what the
collected data adds up to. This adds a monthly aggregate report so operators can
see the distribution of the tests stored on their server.

The report covers download/upload distributions, ping/jitter, client type,
IPv4/IPv6 and country. Results are cached, public reporting is opt-in, and
groups with fewer than 100 tests are not reported separately.

![Telemetry statistics](https://raw.githubusercontent.com/BKPepe/speedtest/screenshots/stats-dark.png)

<details>
<summary>Light theme</summary>

![Light theme](https://raw.githubusercontent.com/BKPepe/speedtest/screenshots/stats-light.png)

</details>

## Why

The CLI is packaged for OpenWrt, and Turris OS runs it on a schedule rather than
on demand, so a router accumulates measurements instead of producing one at a
time. Those routers are not a single platform — Turris Omnia, MOX and Omnia NG
all run it, and the 32-bit PowerPC Turris 1.x cannot run the Go client at all,
which is why a Rust port exists (https://github.com/openwrt/packages/pull/30186).

That raises a question an operator currently cannot answer: what do all those
tests add up to, and is the hardware itself limiting what they show?

It also matters to the people sending the data. Users ask what telemetry is
collected, where it goes, and where they could see it. A published aggregate
answers all three at once, and answers them with the data rather than with a
paragraph of assurance.

None of this is specific to Turris. Anyone collecting telemetry eventually wants
context for the population behind it, and this provides that without inventing
information the telemetry does not contain — there is no notion of DSL or fibre
in it, and none is guessed at.

## Notes

Aggregation is done in PHP because the measurement columns are `text`, malformed
historical values exist, and percentile support differs between the supported
database backends. On SQLite, `MAX(dl)` over `'99.9'`, `'312.5'`, `'1024.0'`,
`''` and `'abc'` returns `'abc'`, and `AVG(dl)` returns 287.28 where the mean of
the real values is 478.8. Percentiles use a sparse histogram, and completed
months are cached permanently.

Malformed measurements are retained as rows but excluded from aggregates.
Individual results, IP addresses and raw User-Agent strings are never published.

Which month is current is taken from the database rather than from PHP, because
the backends disagree on what their timestamp column records: SQLite's
`CURRENT_TIMESTAMP` is UTC, PostgreSQL's `now()` and MSSQL's `getdate()` are
server-local.

Tested against seeded SQLite telemetry, including malformed measurements and
privacy-threshold edge cases. `tests/telemetry_stats_test.php` covers the
helpers directly and is wired into `npm test`, which was previously a stub.

## Follow-up worth considering

The client breakdown can only say what a client calls itself. Extending the CLI
to name its platform in the User-Agent — librespeed/speedtest-cli#131 does this
for the Go client — would let this report show which architectures are measuring
against a server, with no change to what telemetry stores.

___

@ljelinek-cznic, would you be willing to try this on librespeed.turris.cz? The
figures above come from seeded data, and what I cannot check here is whether
they read sensibly against a real month: whether the client split matches what
you would expect, whether the country parsing copes with your `ispinfo`, and how
long `stats_build.php` takes on a table that size.
