### PR TITLE
feat: simulate real-world transport (TCP/TLS overhead, connection setup, slow-start curve) + raw UDP test

### DIFF
--- a/backend/empty.php
+++ b/backend/empty.php
@@ -2,6 +2,9 @@
 
 header('HTTP/1.1 200 OK');
 
+// Expose detailed timing to the browser's Resource Timing API (cross-origin too).
+header('Timing-Allow-Origin: *');
+
 if (isset($_GET['cors'])) {
     header('Access-Control-Allow-Origin: *');
     header('Access-Control-Allow-Methods: GET, POST');

--- a/backend/garbage.php
+++ b/backend/garbage.php
@@ -32,6 +32,10 @@ function sendHeaders()
 {
     header('HTTP/1.1 200 OK');
 
+    // Expose detailed timing (TCP/TLS handshake, transfer size) to the browser's
+    // Resource Timing API, even for cross-origin (multiple points of test) requests.
+    header('Timing-Allow-Origin: *');
+
     if (isset($_GET['cors'])) {
         header('Access-Control-Allow-Origin: *');
         header('Access-Control-Allow-Methods: GET, POST');

--- a/backend/getIP.php
+++ b/backend/getIP.php
@@ -165,6 +165,8 @@ function formatResponse_simple($ip,$ispName=null){
 }
 
 header('Content-Type: application/json; charset=utf-8');
+// Expose detailed timing to the browser's Resource Timing API (cross-origin too).
+header('Timing-Allow-Origin: *');
 if (isset($_GET['cors'])) {
     header('Access-Control-Allow-Origin: *');
     header('Access-Control-Allow-Methods: GET, POST');

--- a/doc.md
+++ b/doc.md
@@ -360,11 +360,11 @@ The `onupdate` event handler will be called periodically by the test with data c
   * `5` = Test aborted
 * __dlStatus__: either
   * Empty string (not started or aborted)
-  * Download speed in Megabit/s as a number with 2 decimals
+  * Estimated download **line rate** in Megabit/s as a number with 2 decimals (payload throughput multiplied by the transport overhead factor, see `overhead_auto`)
   * The string "Fail" (test failed)
 * __ulStatus__: either
   * Empty string (not started or aborted)
-  * Upload speed in Megabit/s as a number with 2 decimals
+  * Estimated upload **line rate** in Megabit/s as a number with 2 decimals (payload throughput multiplied by the transport overhead factor, see `overhead_auto`)
   * The string "Fail" (test failed)
 * __pingStatus__: either
   * Empty string (not started or aborted)
@@ -381,6 +381,13 @@ The `onupdate` event handler will be called periodically by the test with data c
 * __ulProgress__: the progress of the upload test as a number between 0 and 1
 * __pingProgress__: the progress of the ping+jitter test as a number between 0 and 1
 * __testId__: when telemetry is active, this is the ID of the test in the database. This is null until the test is finished, or if telemetry encounters an error. This ID is used for results sharing
+* __dlPayloadStatus__ / __ulPayloadStatus__: application-layer **payload** throughput in Megabit/s with 2 decimals, without any transport overhead compensation. This is the speed a real file download/upload would report.
+* __dlOverheadPct__ / __ulOverheadPct__: estimated transport overhead (TCP/IP/TLS/Ethernet/ACK) as a percentage of the payload, e.g. `7.9`. Empty until the corresponding test runs.
+* __tcpHandshakeMs__: TCP connection setup time in milliseconds (0 when unavailable, e.g. cross-origin without a `Timing-Allow-Origin` header on the server)
+* __tlsHandshakeMs__: TLS handshake time in milliseconds (0 on plain HTTP or when unavailable)
+* __ttfbMs__: time to first byte in milliseconds (0 when unavailable)
+* __nextHopProtocol__: negotiated HTTP protocol (`http/1.1`, `h2`, `h3`) or an empty string when unavailable
+* __dlCurve__ / __ulCurve__: array of `{t, speed}` samples collected every ~200ms during the download/upload test. `t` is milliseconds since the test started and `speed` is the instantaneous payload throughput in Megabit/s. Useful to visualise the TCP slow-start ramp-up.
 
 The `onend` event handler will be called at the end of the test (`onupdate` will be called first), with a boolean telling you if the test was aborted (either manually or because of an error) or if it ended normally.
 
@@ -492,7 +499,7 @@ __Advanced parameters:__ (Seriously, don't change these unless you know what you
   * Default override: `false` on Firefox because its performance API implementation is inaccurate
 * __useMebibits__: use mebibits/s instead of megabits/s for the speeds
   * Default: `false`
-* __overheadCompensationFactor__: compensation for HTTP and network overhead. Default value assumes typical MTUs used over the Internet. You might want to change this if you're using this in your internal network with different MTUs, or if you're using IPv6 instead of IPv4.
+* __overheadCompensationFactor__: manual compensation for HTTP and network overhead, used only when `overhead_auto` is `false`. Default value assumes typical MTUs used over the Internet. You might want to change this if you're using this in your internal network with different MTUs, or if you're using IPv6 instead of IPv4.
   * Default: `1.06` probably a decent estimate for all overhead. This was measured empirically by comparing the measured speed and the speed reported by my network adapter.
   * `1048576/925000`: old default value. This is probably too high.
   * `1.0513`: HTTP+TCP+IPv6+ETH, over the Internet (empirically tested, not calculated)
@@ -501,6 +508,16 @@ __Advanced parameters:__ (Seriously, don't change these unless you know what you
   * `1514 / 1460`: TCP+IPv4+ETH, ignoring HTTP overhead
   * `1514 / 1440`: TCP+IPv6+ETH, ignoring HTTP overhead
   * `1`: ignore overheads. This measures the speed at which you actually download and upload files rather than the raw connection speed
+* __overhead_auto__: if `true`, the transport overhead is estimated from a model (Ethernet + IP + TCP + TLS + reverse ACK) instead of the fixed `overheadCompensationFactor`. The measured payload speed is multiplied by this factor to produce the reported line rate, and the factor minus 1 is reported as the overhead percentage.
+  * Default: `true`
+* __overhead_mtu__: MTU in bytes used by the overhead model.
+  * Default: `1500` (typical for the Internet)
+* __overhead_ipVersion__: IP version used by the overhead model: `4` or `6`.
+  * Default: `4`
+* __overhead_ackFactor__: extra factor accounting for reverse ACK traffic (~2.3% = one ACK every two segments).
+  * Default: `1.023`
+* __report_connection_info__: if `true`, the worker reads Performance Resource Timing entries to report TCP/TLS handshake, TTFB and the negotiated protocol. Requires a `Timing-Allow-Origin` header on the backend for cross-origin (multiple points of test) deployments; same-origin works out of the box.
+  * Default: `true`
 
 ### Multiple Points of Test
 

--- a/doc.md
+++ b/doc.md
@@ -905,6 +905,24 @@ s.setParameter("test_order","P_D_U");
 
 This will point to our static files and set the test to only do ping/jitter, download and upload tests.
 
+## UDP test
+
+The browser test measures TCP/HTTP(S) only — page JavaScript cannot open a raw UDP socket. To measure **UDP throughput, packet loss, RTT and jitter**, LibreSpeed ships a self-contained, zero-dependency Node.js UDP test in the `udp/` directory (see `udp/README.md` for full details).
+
+Server (on your host):
+
+```sh
+node udp/udp-server.js -p 5201
+```
+
+Client (anywhere with UDP access to the server):
+
+```sh
+node udp/udp-client.js -h <server> -p 5201 --all 5
+```
+
+`--all 5` runs ping (30 datagrams), upload and download for 5 seconds each, and prints a JSON result line for scripting. A browser-native UDP path would require WebTransport over HTTP/3 (QUIC) and is not included in this repository yet.
+
 ## Troubleshooting
 
 These are the most common issues reported by users, and how to fix them. If you still need help, contact me at [info@fdossena.com](mailto:info@fdossena.com).

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -69,6 +69,29 @@
         </div>
       </div>
 
+      <div class="transport-details hidden" id="transport-details">
+        <div class="detail-row">
+          <span class="detail-label">Download</span>
+          <span class="detail-value">payload <b id="dl-payload">&mdash;</b> Mbps</span>
+          <span class="detail-value">line <b id="dl-line">&mdash;</b> Mbps</span>
+          <span class="detail-value">overhead <b id="dl-overhead">&mdash;</b>%</span>
+        </div>
+        <div class="detail-row">
+          <span class="detail-label">Upload</span>
+          <span class="detail-value">payload <b id="ul-payload">&mdash;</b> Mbps</span>
+          <span class="detail-value">line <b id="ul-line">&mdash;</b> Mbps</span>
+          <span class="detail-value">overhead <b id="ul-overhead">&mdash;</b>%</span>
+        </div>
+        <div class="detail-row connection">
+          <span class="detail-label">Connection</span>
+          <span class="detail-value">TCP <b id="conn-tcp">&mdash;</b> ms</span>
+          <span class="detail-value">TLS <b id="conn-tls">&mdash;</b> ms</span>
+          <span class="detail-value">TTFB <b id="conn-ttfb">&mdash;</b> ms</span>
+          <span class="detail-value">proto <b id="conn-proto">&mdash;</b></span>
+        </div>
+        <canvas id="throughput-chart" class="hidden" width="600" height="160"></canvas>
+      </div>
+
       <button class="small inverted hidden" id="share-results">
         Share results
       </button>

--- a/frontend/javascript/index.js
+++ b/frontend/javascript/index.js
@@ -305,6 +305,17 @@ function startRenderingLoop() {
   const shareResults = document.querySelector("#share-results");
   const copyLink = document.querySelector("#copy-link");
   const resultsImage = document.querySelector("#results");
+  const transportDetails = document.querySelector("#transport-details");
+  const dlPayload = document.querySelector("#dl-payload");
+  const dlLine = document.querySelector("#dl-line");
+  const dlOverhead = document.querySelector("#dl-overhead");
+  const ulPayload = document.querySelector("#ul-payload");
+  const ulLine = document.querySelector("#ul-line");
+  const ulOverhead = document.querySelector("#ul-overhead");
+  const connTcp = document.querySelector("#conn-tcp");
+  const connTls = document.querySelector("#conn-tls");
+  const connTtfb = document.querySelector("#conn-ttfb");
+  const connProto = document.querySelector("#conn-proto");
 
   const buttonTexts = {
     [INITIALIZING]: "Loading...",
@@ -394,6 +405,30 @@ function startRenderingLoop() {
       ping.textContent = numberToText(testState.testData.pingStatus);
       jitter.textContent = numberToText(testState.testData.jitterStatus);
 
+      // Transport details: payload vs line rate vs overhead, connection info
+      if (testState.testData.dlPayloadStatus) {
+        dlPayload.textContent = testState.testData.dlPayloadStatus;
+        dlLine.textContent = testState.testData.dlStatus;
+        dlOverhead.textContent = testState.testData.dlOverheadPct || "0";
+        ulPayload.textContent = testState.testData.ulPayloadStatus;
+        ulLine.textContent = testState.testData.ulStatus;
+        ulOverhead.textContent = testState.testData.ulOverheadPct || "0";
+        transportDetails.classList.remove("hidden");
+      }
+      if (
+        testState.testData.tcpHandshakeMs ||
+        testState.testData.tlsHandshakeMs ||
+        testState.testData.ttfbMs
+      ) {
+        connTcp.textContent = testState.testData.tcpHandshakeMs || "0";
+        connTls.textContent = testState.testData.tlsHandshakeMs || "0";
+        connTtfb.textContent = testState.testData.ttfbMs || "0";
+      }
+      if (testState.testData.nextHopProtocol) {
+        connProto.textContent = testState.testData.nextHopProtocol;
+      }
+      drawThroughputChart();
+
       // Set user's IP and provider
       if (testState.testData.clientIp) {
         // Clear previous content
@@ -470,4 +505,66 @@ function numberToText(value) {
   if (value < 10) return value.toFixed(2);
   if (value < 100) return value.toFixed(1);
   return value.toFixed(0);
+}
+
+/**
+ * Draw the download/upload throughput-over-time curves (shows the slow-start
+ * ramp-up at the beginning of each test).
+ */
+function drawThroughputChart() {
+  const canvas = document.querySelector("#throughput-chart");
+  if (!canvas || !testState.testData) return;
+  const data = testState.testData;
+
+  const series = [];
+  if (Array.isArray(data.dlCurve) && data.dlCurve.length > 1) {
+    series.push({ color: "#d63bc6", points: data.dlCurve });
+  }
+  if (Array.isArray(data.ulCurve) && data.ulCurve.length > 1) {
+    series.push({ color: "#5cf9fd", points: data.ulCurve });
+  }
+  if (series.length === 0) {
+    canvas.classList.add("hidden");
+    return;
+  }
+  canvas.classList.remove("hidden");
+
+  const dpr = window.devicePixelRatio || 1;
+  const w = canvas.clientWidth || canvas.width;
+  const h = canvas.clientHeight || canvas.height;
+  if (
+    canvas.width !== Math.round(w * dpr) ||
+    canvas.height !== Math.round(h * dpr)
+  ) {
+    canvas.width = Math.round(w * dpr);
+    canvas.height = Math.round(h * dpr);
+  }
+  const ctx = canvas.getContext("2d");
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  ctx.clearRect(0, 0, w, h);
+
+  let maxT = 0;
+  let maxSpeed = 1;
+  series.forEach((s) =>
+    s.points.forEach((p) => {
+      if (p.t > maxT) maxT = p.t;
+      if (p.speed > maxSpeed) maxSpeed = p.speed;
+    })
+  );
+
+  const pad = 8;
+  const plotW = w - pad * 2;
+  const plotH = h - pad * 2;
+  series.forEach((s) => {
+    ctx.strokeStyle = s.color;
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    s.points.forEach((p, i) => {
+      const x = pad + (p.t / maxT) * plotW;
+      const y = pad + plotH - (p.speed / maxSpeed) * plotH;
+      if (i === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    });
+    ctx.stroke();
+  });
 }

--- a/frontend/styling/results.css
+++ b/frontend/styling/results.css
@@ -258,3 +258,68 @@ div.gauge {
   grid-area: ping;
   justify-content: end;
 }
+
+/* Transport details: payload vs line rate, connection info, throughput chart */
+
+.transport-details {
+  margin: 2rem auto 0 auto;
+  max-width: 90rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.8rem;
+  font-size: 1.6rem;
+  letter-spacing: -0.05rem;
+  color: var(--secondary-text-color);
+
+  &.hidden {
+    display: none;
+  }
+
+  .detail-row {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 1.5rem;
+
+    .detail-label {
+      font-weight: 700;
+      text-transform: uppercase;
+      color: var(--ping-and-jitter-secondary-text-color);
+      min-width: 10rem;
+      text-align: right;
+    }
+
+    .detail-value {
+      color: var(--secondary-text-color);
+
+      b {
+        font-weight: 700;
+        color: var(--ping-and-jitter-primary-text-color);
+      }
+    }
+
+    &.connection .detail-value b {
+      color: var(--theme-green);
+    }
+  }
+
+  canvas#throughput-chart {
+    margin-top: 1rem;
+    width: 100%;
+    max-width: 70rem;
+    height: 16rem;
+
+    &.hidden {
+      display: none;
+    }
+  }
+
+  @media screen and (max-width: 500px) {
+    font-size: 1.4rem;
+
+    .detail-row .detail-label {
+      min-width: 8rem;
+    }
+  }
+}

--- a/index-classic.html
+++ b/index-classic.html
@@ -212,6 +212,62 @@
 			drawMeter(I("ulMeter"), mbpsToAmount(Number(uiData.ulStatus * (status == 3 ? oscillate() : 1))), meterBk, ulColor, Number(uiData.ulProgress), progColor);
 			I("pingText").textContent = format(uiData.pingStatus);
 			I("jitText").textContent = format(uiData.jitterStatus);
+			updateDetails();
+		}
+		function updateDetails() {
+			if (!uiData) return;
+			var d = uiData, txt = "";
+			if (d.dlPayloadStatus) {
+				txt += "<b>Download</b>: payload " + d.dlPayloadStatus + " Mbps &middot; line " + d.dlStatus + " Mbps &middot; overhead " + (d.dlOverheadPct || "0") + "%<br>";
+			}
+			if (d.ulPayloadStatus) {
+				txt += "<b>Upload</b>: payload " + d.ulPayloadStatus + " Mbps &middot; line " + d.ulStatus + " Mbps &middot; overhead " + (d.ulOverheadPct || "0") + "%<br>";
+			}
+			if (d.tcpHandshakeMs || d.tlsHandshakeMs || d.ttfbMs) {
+				txt += "<b>Connection</b>: TCP " + (d.tcpHandshakeMs || 0) + " ms &middot; TLS " + (d.tlsHandshakeMs || 0) + " ms &middot; TTFB " + (d.ttfbMs || 0) + " ms";
+				if (d.nextHopProtocol) txt += " &middot; " + d.nextHopProtocol;
+			}
+			if (txt) {
+				I("detailsArea").style.display = "";
+				I("detailsText").innerHTML = txt;
+			}
+			drawCurve();
+		}
+		function drawCurve() {
+			var c = I("curveCanvas");
+			if (!c || !uiData) return;
+			var series = [];
+			if (uiData.dlCurve && uiData.dlCurve.length > 1) series.push({ color: dlColor, points: uiData.dlCurve });
+			if (uiData.ulCurve && uiData.ulCurve.length > 1) series.push({ color: ulColor, points: uiData.ulCurve });
+			if (!series.length) { c.style.display = "none"; return; }
+			c.style.display = "";
+			var dp = window.devicePixelRatio || 1;
+			var w = c.clientWidth, h = c.clientHeight;
+			if (c.width != Math.round(w * dp) || c.height != Math.round(h * dp)) { c.width = Math.round(w * dp); c.height = Math.round(h * dp); }
+			var ctx = c.getContext("2d");
+			ctx.setTransform(dp, 0, 0, dp, 0, 0);
+			ctx.clearRect(0, 0, w, h);
+			var maxT = 0, maxS = 1, si, pi, p;
+			for (si = 0; si < series.length; si++) {
+				for (pi = 0; pi < series[si].points.length; pi++) {
+					p = series[si].points[pi];
+					if (p.t > maxT) maxT = p.t;
+					if (p.speed > maxS) maxS = p.speed;
+				}
+			}
+			var pad = 8, plotW = w - pad * 2, plotH = h - pad * 2;
+			for (si = 0; si < series.length; si++) {
+				ctx.strokeStyle = series[si].color;
+				ctx.lineWidth = 2;
+				ctx.beginPath();
+				for (pi = 0; pi < series[si].points.length; pi++) {
+					p = series[si].points[pi];
+					var x = pad + (p.t / maxT) * plotW;
+					var y = pad + plotH - (p.speed / maxS) * plotH;
+					if (pi === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+				}
+				ctx.stroke();
+			}
 		}
 		function oscillate() {
 			return 1 + 0.02 * Math.sin(Date.now() / 100);
@@ -452,6 +508,23 @@
 			padding: 1em 3em;
 		}
 
+		#detailsArea {
+			margin: 1em auto;
+			max-width: 40em;
+			text-align: center;
+			font-size: 0.9em;
+			line-height: 1.6em;
+		}
+
+		#detailsText {
+			margin: 0.5em 0;
+		}
+
+		#curveCanvas {
+			max-width: 95%;
+			margin: 0.5em auto;
+		}
+
 		@media all and (max-width:40em) {
 			body {
 				font-size: 0.8em;
@@ -557,6 +630,10 @@
 					<div id="ulText" class="meterText"></div>
 					<div class="unit">Mbit/s</div>
 				</div>
+			</div>
+			<div id="detailsArea" style="display:none">
+				<div id="detailsText"></div>
+				<canvas id="curveCanvas" width="600" height="160"></canvas>
 			</div>
 			<div id="ipArea">
 				<span id="ip"></span>

--- a/index-modern.html
+++ b/index-modern.html
@@ -72,6 +72,29 @@
       </div>
     </div>
 
+    <div class="transport-details hidden" id="transport-details">
+      <div class="detail-row">
+        <span class="detail-label">Download</span>
+        <span class="detail-value">payload <b id="dl-payload">&mdash;</b> Mbps</span>
+        <span class="detail-value">line <b id="dl-line">&mdash;</b> Mbps</span>
+        <span class="detail-value">overhead <b id="dl-overhead">&mdash;</b>%</span>
+      </div>
+      <div class="detail-row">
+        <span class="detail-label">Upload</span>
+        <span class="detail-value">payload <b id="ul-payload">&mdash;</b> Mbps</span>
+        <span class="detail-value">line <b id="ul-line">&mdash;</b> Mbps</span>
+        <span class="detail-value">overhead <b id="ul-overhead">&mdash;</b>%</span>
+      </div>
+      <div class="detail-row connection">
+        <span class="detail-label">Connection</span>
+        <span class="detail-value">TCP <b id="conn-tcp">&mdash;</b> ms</span>
+        <span class="detail-value">TLS <b id="conn-tls">&mdash;</b> ms</span>
+        <span class="detail-value">TTFB <b id="conn-ttfb">&mdash;</b> ms</span>
+        <span class="detail-value">proto <b id="conn-proto">&mdash;</b></span>
+      </div>
+      <canvas id="throughput-chart" class="hidden" width="600" height="160"></canvas>
+    </div>
+
     <button class="small inverted hidden" id="share-results">
       Share results
     </button>

--- a/settings.json
+++ b/settings.json
@@ -5,5 +5,10 @@
   "time_ul_max": 12,
   "time_dlGraceTime": 0,
   "time_ulGraceTime": 0,
-  "time_auto": false
+  "time_auto": false,
+  "overhead_auto": true,
+  "overhead_mtu": 1500,
+  "overhead_ipVersion": 4,
+  "overhead_ackFactor": 1.023,
+  "report_connection_info": true
 }

--- a/speedtest_worker.js
+++ b/speedtest_worker.js
@@ -17,6 +17,18 @@ let ulProgress = 0; //progress of upload test 0-1
 let pingProgress = 0; //progress of ping+jitter test 0-1
 let testId = null; //test ID (sent back by telemetry if used, null otherwise)
 
+// real-world transport metrics: payload throughput vs estimated line rate, connection setup timings
+let dlPayloadStatus = ""; // download payload throughput in Mbit/s (no overhead compensation)
+let ulPayloadStatus = ""; // upload payload throughput in Mbit/s (no overhead compensation)
+let dlOverheadPct = ""; // estimated transport overhead for download, as a percentage
+let ulOverheadPct = ""; // estimated transport overhead for upload, as a percentage
+let tcpHandshakeMs = 0; // TCP connection setup time in ms
+let tlsHandshakeMs = 0; // TLS handshake time in ms
+let ttfbMs = 0; // time to first byte in ms
+let nextHopProtocol = ""; // negotiated protocol (h2 / h3 / http/1.1)
+let dlCurve = []; // download throughput samples over time [{t, speed}] (payload Mbit/s)
+let ulCurve = []; // upload throughput samples over time [{t, speed}] (payload Mbit/s)
+
 let log = ""; //telemetry log
 function tlog(s) {
 	if (settings.telemetry_level >= 2) {
@@ -60,7 +72,12 @@ let settings = {
 	garbagePhp_chunkSize: 100, // size of chunks sent by garbage.php (can be different if enable_quirks is active)
 	enable_quirks: true, // enable quirks for specific browsers. currently it overrides settings to optimize for specific browsers, unless they are already being overridden with the start command
 	ping_allowPerformanceApi: true, // if enabled, the ping test will attempt to calculate the ping more precisely using the Performance API. Currently works perfectly in Chrome, badly in Edge, and not at all in Firefox. If Performance API is not supported or the result is obviously wrong, a fallback is provided.
-	overheadCompensationFactor: 1.06, //can be changed to compensate for transport overhead. (see doc.md for some other values)
+	overheadCompensationFactor: 1.06, //manual transport overhead factor, used when overhead_auto is false (see doc.md for some other values)
+	overhead_auto: true, //if true, estimate transport overhead from the model below (MTU/IP/TCP/TLS/ACK) instead of using the fixed overheadCompensationFactor
+	overhead_mtu: 1500, //MTU in bytes used by the overhead model (1500 is typical for the internet)
+	overhead_ipVersion: 4, //IP version used by the overhead model: 4 or 6
+	overhead_ackFactor: 1.023, //extra factor for reverse ACK traffic (~2.3% = 1 ACK every 2 segments)
+	report_connection_info: true, //collect and report TCP/TLS handshake, TTFB and negotiated protocol via Resource Timing
 	useMebibits: false, //if set to true, speed will be reported in mebibits/s instead of megabits/s
 	telemetry_level: 0, // 0=disabled, 1=basic (results only), 2=full (results and timing) 3=debug (results+log)
 	url_telemetry: "results/telemetry.php", // path to the script that adds telemetry data to the database
@@ -80,6 +97,73 @@ function url_sep(url) {
 }
 
 /*
+  Estimate the ratio between raw wire bits and payload bits (transport overhead).
+  This models a typical Ethernet + IP + TCP + TLS 1.3 connection so that the
+  measured application-layer throughput can be converted into an estimated line rate.
+*/
+function currentOverheadFactor() {
+	if (!settings.overhead_auto) return settings.overheadCompensationFactor || 1;
+	const mtu = Number(settings.overhead_mtu) || 1500;
+	const ip = Number(settings.overhead_ipVersion) === 6 ? 40 : 20;
+	const tcp = 20; // typical TCP header (no options)
+	const eth = 38; // preamble+sfd(8) + eth header(14) + fcs(4) + interframe gap(12)
+	const tls = 21; // TLS 1.3 record header(5) + AEAD tag(16) per record
+	const tlsRec = 16384; // max TLS record payload
+	const ack = Number(settings.overhead_ackFactor) || 1.023;
+	const mss = mtu - ip - tcp;
+	if (mss <= 0) return settings.overheadCompensationFactor || 1;
+	return (1 + (eth + ip + tcp) / mss + tls / tlsRec) * ack;
+}
+
+/*
+  Read PerformanceResourceTiming entries produced by this worker to extract the
+  real connection setup timings (TCP/TLS handshake, TTFB) and the negotiated
+  protocol. Values are written to the module-level variables consumed by the
+  status handler. Cross-origin entries only expose these fields when the server
+  sends a Timing-Allow-Origin header.
+*/
+function collectNetworkInfo() {
+	if (!settings.report_connection_info) return;
+	try {
+		const entries = performance.getEntriesByType("resource");
+		if (!entries || !entries.length) return;
+		const bases = [settings.url_dl, settings.url_ul, settings.url_ping, settings.url_getIp]
+			.map(function(u) { return (u || "").split("?")[0]; })
+			.filter(function(u) { return u.length > 0; });
+		let tcp = 0, tls = 0, ttfb = 0, proto = "";
+		for (let i = entries.length - 1; i >= 0; i--) {
+			const e = entries[i];
+			const name = (e.name || "").split("?")[0];
+			let matched = false;
+			for (let b = 0; b < bases.length; b++) {
+				if (name.indexOf(bases[b]) !== -1) { matched = true; break; }
+			}
+			if (!matched) continue;
+			if (!proto && e.nextHopProtocol) proto = e.nextHopProtocol;
+			if (e.secureConnectionStart > 0 && e.connectStart > 0) {
+				const tlsMs = e.connectEnd - e.secureConnectionStart;
+				const tcpMs = e.secureConnectionStart - e.connectStart;
+				if (tlsMs > tls) tls = tlsMs;
+				if (tcpMs > tcp) tcp = tcpMs;
+			} else if (e.connectStart > 0) {
+				const tcpMs = e.connectEnd - e.connectStart;
+				if (tcpMs > tcp) tcp = tcpMs;
+			}
+			if (e.requestStart > 0 && e.responseStart > 0) {
+				const ttfbMs = e.responseStart - e.requestStart;
+				if (ttfbMs > 0 && (!ttfb || ttfbMs < ttfb)) ttfb = ttfbMs;
+			}
+		}
+		tcpHandshakeMs = Math.round(tcp);
+		tlsHandshakeMs = Math.round(tls);
+		ttfbMs = Math.round(ttfb);
+		nextHopProtocol = proto;
+	} catch (e) {
+		// Resource Timing unavailable or entries unreadable: leave metrics at 0
+	}
+}
+
+/*
 	listener for commands from main thread to this worker.
 	commands:
 	-status: returns the current status as a JSON string containing testState, dlStatus, ulStatus, pingStatus, clientIp, jitterStatus, dlProgress, ulProgress, pingProgress
@@ -91,6 +175,7 @@ this.addEventListener("message", function(e) {
 	const params = e.data.split(" ");
 	if (params[0] === "status") {
 		// return status
+		collectNetworkInfo();
 		postMessage(
 			JSON.stringify({
 				testState: testState,
@@ -102,7 +187,17 @@ this.addEventListener("message", function(e) {
 				dlProgress: dlProgress,
 				ulProgress: ulProgress,
 				pingProgress: pingProgress,
-				testId: testId
+				testId: testId,
+				dlPayloadStatus: dlPayloadStatus,
+				ulPayloadStatus: ulPayloadStatus,
+				dlOverheadPct: dlOverheadPct,
+				ulOverheadPct: ulOverheadPct,
+				tcpHandshakeMs: tcpHandshakeMs,
+				tlsHandshakeMs: tlsHandshakeMs,
+				ttfbMs: ttfbMs,
+				nextHopProtocol: nextHopProtocol,
+				dlCurve: dlCurve,
+				ulCurve: ulCurve
 			})
 		);
 	}
@@ -261,6 +356,16 @@ this.addEventListener("message", function(e) {
 		dlProgress = 0;
 		ulProgress = 0;
 		pingProgress = 0;
+		dlPayloadStatus = "";
+		ulPayloadStatus = "";
+		dlOverheadPct = "";
+		ulOverheadPct = "";
+		tcpHandshakeMs = 0;
+		tlsHandshakeMs = 0;
+		ttfbMs = 0;
+		nextHopProtocol = "";
+		dlCurve = [];
+		ulCurve = [];
 	}
 });
 // stops all XHR activity, aggressively
@@ -326,7 +431,10 @@ function dlTest(done) {
 		startT = new Date().getTime(), // timestamp when test was started
 		bonusT = 0, //how many milliseconds the test has been shortened by (higher on faster connections)
 		graceTimeDone = false, //set to true after the grace time is past
-		failed = false; // set to true if a stream fails
+		failed = false, // set to true if a stream fails
+		curveStartT = new Date().getTime(), // monotonic clock used for the throughput curve
+		curveLast = 0; // previous totLoaded value, used to sample instantaneous throughput
+	dlCurve = [];
 	xhr = [];
 	// function to create a download stream. streams are slightly delayed so that they will not end at the same time
 	const testStream = function(i, delay) {
@@ -389,6 +497,12 @@ function dlTest(done) {
 			tverb("DL: " + dlStatus + (graceTimeDone ? "" : " (in grace time)"));
 			const t = new Date().getTime() - startT;
 			if (graceTimeDone) dlProgress = (t + bonusT) / (settings.time_dl_max * 1000);
+			// sample instantaneous throughput for the slow-start curve (bytes in the last 200ms)
+			const curveDelta = totLoaded - curveLast;
+			curveLast = totLoaded;
+			if (curveDelta >= 0) {
+				dlCurve.push({ t: new Date().getTime() - curveStartT, speed: (curveDelta / 0.2) * 8 / (settings.useMebibits ? 1048576 : 1000000) });
+			}
 			if (t < 200) return;
 			if (!graceTimeDone) {
 				if (t > 1000 * settings.time_dlGraceTime) {
@@ -407,8 +521,12 @@ function dlTest(done) {
 					const bonus = (5.0 * speed) / 100000;
 					bonusT += bonus > 400 ? 400 : bonus;
 				}
-				//update status
-				dlStatus = ((speed * 8 * settings.overheadCompensationFactor) / (settings.useMebibits ? 1048576 : 1000000)).toFixed(2); // speed is multiplied by 8 to go from bytes to bits, overhead compensation is applied, then everything is divided by 1048576 or 1000000 to go to megabits/mebibits
+				//update status. speed is multiplied by 8 to go from bytes to bits, then divided by 1048576 or 1000000 to go to megabits/mebibits
+				const payloadMbps = (speed * 8) / (settings.useMebibits ? 1048576 : 1000000);
+				const overhead = currentOverheadFactor();
+				dlPayloadStatus = payloadMbps.toFixed(2);
+				dlOverheadPct = ((overhead - 1) * 100).toFixed(1);
+				dlStatus = (payloadMbps * overhead).toFixed(2);
 				if ((t + bonusT) / 1000.0 > settings.time_dl_max || failed) {
 					// test is over, stop streams and timer
 					if (failed || isNaN(dlStatus)) dlStatus = "Fail";
@@ -452,7 +570,10 @@ function ulTest(done) {
 			startT = new Date().getTime(), // timestamp when test was started
 			bonusT = 0, //how many milliseconds the test has been shortened by (higher on faster connections)
 			graceTimeDone = false, //set to true after the grace time is past
-			failed = false; // set to true if a stream fails
+			failed = false, // set to true if a stream fails
+			curveStartT = new Date().getTime(), // monotonic clock used for the throughput curve
+			curveLast = 0; // previous totLoaded value, used to sample instantaneous throughput
+		ulCurve = [];
 		xhr = [];
 		// function to create an upload stream. streams are slightly delayed so that they will not end at the same time
 		const testStream = function(i, delay) {
@@ -547,6 +668,12 @@ function ulTest(done) {
 				tverb("UL: " + ulStatus + (graceTimeDone ? "" : " (in grace time)"));
 				const t = new Date().getTime() - startT;
 				if (graceTimeDone) ulProgress = (t + bonusT) / (settings.time_ul_max * 1000);
+				// sample instantaneous throughput for the slow-start curve (bytes in the last 200ms)
+				const curveDelta = totLoaded - curveLast;
+				curveLast = totLoaded;
+				if (curveDelta >= 0) {
+					ulCurve.push({ t: new Date().getTime() - curveStartT, speed: (curveDelta / 0.2) * 8 / (settings.useMebibits ? 1048576 : 1000000) });
+				}
 				if (t < 200) return;
 				if (!graceTimeDone) {
 					if (t > 1000 * settings.time_ulGraceTime) {
@@ -565,8 +692,12 @@ function ulTest(done) {
 						const bonus = (5.0 * speed) / 100000;
 						bonusT += bonus > 400 ? 400 : bonus;
 					}
-					//update status
-					ulStatus = ((speed * 8 * settings.overheadCompensationFactor) / (settings.useMebibits ? 1048576 : 1000000)).toFixed(2); // speed is multiplied by 8 to go from bytes to bits, overhead compensation is applied, then everything is divided by 1048576 or 1000000 to go to megabits/mebibits
+					//update status. speed is multiplied by 8 to go from bytes to bits, then divided by 1048576 or 1000000 to go to megabits/mebibits
+					const payloadMbps = (speed * 8) / (settings.useMebibits ? 1048576 : 1000000);
+					const overhead = currentOverheadFactor();
+					ulPayloadStatus = payloadMbps.toFixed(2);
+					ulOverheadPct = ((overhead - 1) * 100).toFixed(1);
+					ulStatus = (payloadMbps * overhead).toFixed(2);
 					if ((t + bonusT) / 1000.0 > settings.time_ul_max || failed) {
 						// test is over, stop streams and timer
 						if (failed || isNaN(ulStatus)) ulStatus = "Fail";

--- a/udp/README.md
+++ b/udp/README.md
@@ -1,0 +1,88 @@
+# LibreSpeed UDP test
+
+A raw-UDP speed test for LibreSpeed, in the spirit of iperf3: it measures
+**throughput, packet loss, RTT and jitter over UDP**, which the browser-based
+test cannot do (browsers expose no raw UDP socket).
+
+It is a self-contained pair of Node.js scripts with **zero dependencies** (only
+the built-in `dgram` module). Node.js 12+ is sufficient.
+
+## Why not in the browser?
+
+The browser speed test (`speedtest_worker.js`) can only speak HTTP(S) over TCP.
+There is no way for page JavaScript to send raw UDP datagrams. The closest
+browser-native alternative is WebTransport over HTTP/3 (QUIC), which runs on UDP
+under the hood but requires an HTTP/3-capable server and Chromium — that is a
+separate, optional path and is not included here.
+
+## Quick start
+
+Server (run on your LibreSpeed host):
+
+```sh
+node udp/udp-server.js -p 5201
+```
+
+Client (run anywhere that can reach the server over UDP):
+
+```sh
+node udp/udp-client.js -h <server> -p 5201 --all 5
+```
+
+`--all 5` runs ping (30 packets), upload and download for 5 seconds each.
+
+## Options
+
+### Server
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `-p, --port` | `5201` | UDP port to listen on |
+| `-6, --ipv6` | off | use IPv6 |
+| `--datagram` | `1200` | payload size in bytes (kept below the MTU to avoid IP fragmentation) |
+
+### Client
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `-h, --host` | `127.0.0.1` | server host |
+| `-p, --port` | `5201` | server port |
+| `-6, --ipv6` | off | use IPv6 |
+| `--datagram` | `1200` | payload size in bytes |
+| `--ping <n>` | | send `n` ping datagrams, report RTT / jitter / loss |
+| `--upload <sec>` | | flood upload datagrams for `sec` seconds |
+| `--download <sec>` | | receive download datagrams for `sec` seconds |
+| `--all <sec>` | | run ping (30) + upload + download, `sec` seconds each |
+
+## Example output
+
+```
+PING   sent=30 received=30 loss=0.0% rtt=6.50ms (min 5.00, max 8.00) jitter=0.10ms
+UPLOAD sent=305.81Mbps received=305.81Mbps loss=0.00% (63500 -> 63500 pkts)
+DOWNLOAD sent=300.82Mbps received=300.82Mbps loss=0.00% (62000 -> 62000 pkts)
+```
+
+A JSON array with the same results is printed as the last line, so the client
+can be scripted.
+
+## How it maps to LibreSpeed's metrics
+
+| Browser test (TCP/HTTP) | UDP test |
+| --- | --- |
+| Download / Upload (Mbps) | `DOWNLOAD` / `UPLOAD` (Mbps) |
+| Ping / Jitter (ms) | `PING` RTT / jitter (ms) |
+| (implicit, HTTP retries) | explicit **packet loss %** — a UDP-only metric |
+
+## Protocol
+
+See `protocol.js`. Every datagram carries a 13-byte header
+(`type` + `seq` + `timestamp`) followed by an optional payload. The server echoes
+pings, counts upload datagrams, and floods download datagrams; loss is computed
+by comparing the sender's and receiver's packet counters.
+
+## Security notes
+
+- The server binds `0.0.0.0` by default and has **no authentication**. Expose it
+  only on a trusted network, or firewall the port.
+- It reflects the client's source address/port, so it cannot be used as a UDP
+  amplifier (responses are at most the size of the requests).

--- a/udp/protocol.js
+++ b/udp/protocol.js
@@ -1,0 +1,65 @@
+"use strict";
+
+/*
+ * Minimal UDP speed-test protocol (mini-iperf3 style).
+ *
+ * Every datagram has a fixed 13-byte header:
+ *   byte 0      : type (single ASCII char)
+ *   bytes 1-4   : sequence number (uint32 big-endian)
+ *   bytes 5-12  : timestamp in milliseconds (uint64 big-endian)
+ *   bytes 13+   : payload
+ *
+ * Client -> Server:
+ *   P : ping request  (server echoes it back as 'p' with the same seq + timestamp)
+ *   U : upload data   (server counts and discards)
+ *   S : start download (payload starts with uint32 duration_ms; server floods 'D')
+ *   E : end of upload (server reports upload counters and resets them)
+ *
+ * Server -> Client:
+ *   p : ping echo
+ *   D : download data
+ *   R : report (payload is a JSON string)
+ */
+
+const HEADER_SIZE = 13;
+
+const TYPE_PING = 0x50; // 'P'
+const TYPE_UPLOAD = 0x55; // 'U'
+const TYPE_START_DL = 0x53; // 'S'
+const TYPE_END = 0x45; // 'E'
+const TYPE_PING_ECHO = 0x70; // 'p'
+const TYPE_DOWNLOAD = 0x44; // 'D'
+const TYPE_REPORT = 0x52; // 'R'
+
+function encode(type, seq, timestampMs, payload) {
+  const payloadBuf = payload ? Buffer.from(payload) : Buffer.alloc(0);
+  const buf = Buffer.alloc(HEADER_SIZE + payloadBuf.length);
+  buf[0] = type;
+  buf.writeUInt32BE(seq >>> 0, 1);
+  buf.writeBigUInt64BE(BigInt(timestampMs), 5);
+  payloadBuf.copy(buf, HEADER_SIZE);
+  return buf;
+}
+
+function decode(buf) {
+  if (!buf || buf.length < HEADER_SIZE) return null;
+  return {
+    type: buf[0],
+    seq: buf.readUInt32BE(1),
+    timestamp: Number(buf.readBigUInt64BE(5)),
+    payload: buf.subarray(HEADER_SIZE)
+  };
+}
+
+module.exports = {
+  HEADER_SIZE,
+  TYPE_PING,
+  TYPE_UPLOAD,
+  TYPE_START_DL,
+  TYPE_END,
+  TYPE_PING_ECHO,
+  TYPE_DOWNLOAD,
+  TYPE_REPORT,
+  encode,
+  decode
+};

--- a/udp/udp-client.js
+++ b/udp/udp-client.js
@@ -1,0 +1,269 @@
+"use strict";
+
+/*
+ * LibreSpeed UDP test client (mini-iperf3 style, raw UDP).
+ *
+ * Usage:
+ *   node udp-client.js [-h <host>] [-p <port>] [-6] [--datagram <bytes>]
+ *                      [--ping <n>] [--upload <sec>] [--download <sec>] [--all <sec>]
+ *
+ *   -h, --host       server host (default 127.0.0.1)
+ *   -p, --port       server port (default 5201)
+ *   -6, --ipv6       use IPv6
+ *   --datagram       payload size in bytes for throughput datagrams (default 1200)
+ *   --ping <n>       send n ping datagrams and report RTT / jitter / loss
+ *   --upload <sec>   flood upload datagrams for <sec> seconds
+ *   --download <sec> receive download datagrams for <sec> seconds
+ *   --all <sec>      run ping (30) + upload + download, each using <sec> seconds
+ *
+ * Results are printed as human-readable lines and as a single JSON object.
+ */
+
+const dgram = require("dgram");
+const P = require("./protocol");
+
+const args = parseArgs(process.argv.slice(2));
+const HOST = args.host;
+const PORT = args.port;
+const DATAGRAM = args.datagram;
+const sock = dgram.createSocket(args.ipv6 ? "udp6" : "udp4");
+
+function parseArgs(argv) {
+  const out = { host: "127.0.0.1", port: 5201, datagram: 1200, ipv6: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "-h" || a === "--host") out.host = argv[++i];
+    else if (a === "-p" || a === "--port") out.port = parseInt(argv[++i], 10);
+    else if (a === "-6" || a === "--ipv6") out.ipv6 = true;
+    else if (a === "--datagram") out.datagram = parseInt(argv[++i], 10);
+    else if (a === "--ping") out.ping = parseInt(argv[++i], 10);
+    else if (a === "--upload") out.upload = parseFloat(argv[++i]);
+    else if (a === "--download") out.download = parseFloat(argv[++i]);
+    else if (a === "--all") out.all = parseFloat(argv[++i]);
+    else if (a === "--help") out.help = true;
+  }
+  return out;
+}
+
+if (args.help) {
+  console.log(
+    "LibreSpeed UDP client\n\n" +
+    "  node udp-client.js [-h <host>] [-p <port>] [-6] [--datagram <bytes>]\n" +
+    "                     [--ping <n>] [--upload <sec>] [--download <sec>] [--all <sec>]\n"
+  );
+  process.exit(0);
+}
+
+// The current message collector (installed per test). Receives decoded packets.
+let collector = null;
+
+sock.on("message", function(msg) {
+  const p = P.decode(msg);
+  if (p && collector) collector(p, msg.length);
+});
+
+sock.on("error", function(err) {
+  console.error("client error:", err.message);
+  process.exit(1);
+});
+
+function nowMs() {
+  return Number(process.hrtime.bigint() / 1000000n);
+}
+
+function mbps(bytes, seconds) {
+  return (bytes * 8) / seconds / 1000000;
+}
+
+function fmt(n, digits) {
+  return typeof n === "number" ? n.toFixed(digits === undefined ? 2 : digits) : String(n);
+}
+
+// ---- ping / jitter / loss -------------------------------------------------
+function pingTest(count) {
+  return new Promise(function(resolve) {
+    const rtts = [];
+    const sentAt = new Map(); // seq -> client timestamp ms
+    let received = 0;
+
+    collector = function(p) {
+      if (p.type !== P.TYPE_PING_ECHO) return;
+      const sent = sentAt.get(p.seq);
+      if (sent === undefined) return;
+      rtts.push(nowMs() - p.timestamp); // server echoes the client timestamp
+      received++;
+    };
+
+    for (let seq = 0; seq < count; seq++) {
+      sentAt.set(seq, nowMs());
+      sock.send(P.encode(P.TYPE_PING, seq, sentAt.get(seq)), PORT, HOST);
+    }
+
+    // wait for echoes (2s grace), then finish
+    setTimeout(function() {
+      collector = null;
+      const loss = count > 0 ? (count - received) / count : 0;
+      rtts.sort(function(a, b) { return a - b; });
+      const avg = rtts.length ? rtts.reduce(function(a, b) { return a + b; }, 0) / rtts.length : 0;
+      const min = rtts.length ? rtts[0] : 0;
+      const max = rtts.length ? rtts[rtts.length - 1] : 0;
+      // jitter = mean absolute difference between consecutive RTTs
+      let jitter = 0;
+      for (let i = 1; i < rtts.length; i++) jitter += Math.abs(rtts[i] - rtts[i - 1]);
+      if (rtts.length > 1) jitter /= rtts.length - 1;
+      resolve({
+        kind: "ping",
+        sent: count,
+        received: received,
+        loss: loss * 100,
+        avgMs: avg,
+        minMs: min,
+        maxMs: max,
+        jitterMs: jitter
+      });
+    }, 2000);
+  });
+}
+
+// ---- upload ---------------------------------------------------------------
+function uploadTest(seconds) {
+  return new Promise(function(resolve) {
+    const payload = Buffer.alloc(DATAGRAM, 0xcd);
+    let sentBytes = 0;
+    let sentPackets = 0;
+    let seq = 0;
+    let report = null;
+
+    collector = function(p) {
+      if (p.type === P.TYPE_REPORT && p.payload.length) {
+        try { report = JSON.parse(p.payload.toString()); } catch (e) {}
+      }
+    };
+
+    (async function() {
+      const durationMs = Math.round(seconds * 1000);
+      const startAt = process.hrtime.bigint();
+      const endAt = startAt + BigInt(durationMs) * 1000000n;
+      while (process.hrtime.bigint() < endAt) {
+        for (let i = 0; i < 500; i++) {
+          const pkt = P.encode(P.TYPE_UPLOAD, seq++, Date.now(), payload);
+          sock.send(pkt, PORT, HOST);
+          sentBytes += pkt.length;
+          sentPackets++;
+        }
+        await new Promise(function(r) { setImmediate(r); });
+      }
+      const elapsed = Number(process.hrtime.bigint() - startAt) / 1e9;
+
+      // signal end of upload and wait for the server's report
+      sock.send(P.encode(P.TYPE_END, 0, Date.now()), PORT, HOST);
+      await new Promise(function(r) { setTimeout(r, 1500); });
+      collector = null;
+
+      const receivedBytes = report ? report.bytes : 0;
+      const receivedPackets = report ? report.packets : 0;
+      const loss = sentPackets > 0 ? (sentPackets - receivedPackets) / sentPackets : 0;
+      resolve({
+        kind: "upload",
+        seconds: elapsed,
+        sentBytes: sentBytes,
+        sentPackets: sentPackets,
+        receivedBytes: receivedBytes,
+        receivedPackets: receivedPackets,
+        loss: loss * 100,
+        sentMbps: mbps(sentBytes, elapsed),
+        receivedMbps: mbps(receivedBytes, elapsed)
+      });
+    })();
+  });
+}
+
+// ---- download -------------------------------------------------------------
+function downloadTest(seconds) {
+  return new Promise(function(resolve) {
+    let receivedBytes = 0;
+    let receivedPackets = 0;
+    let report = null;
+
+    collector = function(p, msgLen) {
+      if (p.type === P.TYPE_DOWNLOAD) {
+        receivedBytes += msgLen;
+        receivedPackets++;
+      } else if (p.type === P.TYPE_REPORT && p.payload.length) {
+        try { report = JSON.parse(p.payload.toString()); } catch (e) {}
+      }
+    };
+
+    const durationMs = Math.round(seconds * 1000);
+    const durBuf = Buffer.alloc(4);
+    durBuf.writeUInt32BE(durationMs, 0);
+    sock.send(P.encode(P.TYPE_START_DL, 0, Date.now(), durBuf), PORT, HOST);
+
+    // collect for the requested duration plus a small grace for the final report
+    setTimeout(function() {
+      collector = null;
+      const sentBytes = report ? report.bytes : 0;
+      const sentPackets = report ? report.packets : 0;
+      const loss = sentPackets > 0 ? (sentPackets - receivedPackets) / sentPackets : 0;
+      resolve({
+        kind: "download",
+        seconds: seconds,
+        sentBytes: sentBytes,
+        sentPackets: sentPackets,
+        receivedBytes: receivedBytes,
+        receivedPackets: receivedPackets,
+        loss: loss * 100,
+        sentMbps: mbps(sentBytes, seconds),
+        receivedMbps: mbps(receivedBytes, seconds)
+      });
+    }, durationMs + 1500);
+  });
+}
+
+// ---- main -----------------------------------------------------------------
+(async function main() {
+  const results = [];
+
+  if (args.all) {
+    const sec = args.all;
+    results.push(await pingTest(30));
+    results.push(await uploadTest(sec));
+    results.push(await downloadTest(sec));
+  } else {
+    if (args.ping) results.push(await pingTest(args.ping));
+    if (args.upload) results.push(await uploadTest(args.upload));
+    if (args.download) results.push(await downloadTest(args.download));
+  }
+
+  if (results.length === 0) {
+    console.log("Nothing to do. Use --ping <n>, --upload <sec>, --download <sec> or --all <sec>.");
+    process.exit(1);
+  }
+
+  printResults(results);
+  console.log("\nJSON: " + JSON.stringify(results));
+  sock.close();
+})();
+
+function printResults(results) {
+  for (const r of results) {
+    if (r.kind === "ping") {
+      console.log(
+        "PING   sent=" + r.sent + " received=" + r.received +
+        " loss=" + fmt(r.loss, 1) + "%" +
+        " rtt=" + fmt(r.avgMs) + "ms (min " + fmt(r.minMs) + ", max " + fmt(r.maxMs) +
+        ") jitter=" + fmt(r.jitterMs) + "ms"
+      );
+    } else if (r.kind === "upload") {
+      console.log(
+        "UPLOAD sent=" + fmt(r.sentMbps) + "Mbps received=" + fmt(r.receivedMbps) +
+        "Mbps loss=" + fmt(r.loss, 2) + "% (" + r.sentPackets + " -> " + r.receivedPackets + " pkts)"
+      );
+    } else if (r.kind === "download") {
+      console.log(
+        "DOWNLOAD sent=" + fmt(r.sentMbps) + "Mbps received=" + fmt(r.receivedMbps) +
+        "Mbps loss=" + fmt(r.loss, 2) + "% (" + r.sentPackets + " -> " + r.receivedPackets + " pkts)"
+      );
+    }
+  }
+}

--- a/udp/udp-server.js
+++ b/udp/udp-server.js
@@ -1,0 +1,139 @@
+"use strict";
+
+/*
+ * LibreSpeed UDP test server (mini-iperf3 style, raw UDP).
+ *
+ * Usage:
+ *   node udp-server.js [-p <port>] [-6] [--datagram <bytes>]
+ *
+ *   -p, --port       UDP port to listen on (default 5201)
+ *   -6, --ipv6       use IPv6 instead of IPv4
+ *   --datagram       payload size in bytes for throughput datagrams (default 1200)
+ *
+ * This server only speaks the udp/protocol.js wire format. It echoes ping
+ * datagrams, counts upload datagrams, and floods download datagrams on request.
+ * It intentionally avoids IP fragmentation by keeping datagrams small.
+ */
+
+const dgram = require("dgram");
+const P = require("./protocol");
+
+const args = parseArgs(process.argv.slice(2));
+const HOST = args.ipv6 ? "::" : "0.0.0.0";
+const PORT = args.port;
+const DATAGRAM = args.datagram;
+
+const sock = dgram.createSocket(args.ipv6 ? "udp6" : "udp4");
+
+// counters for the current client session
+let uploadBytes = 0;
+let uploadPackets = 0;
+let downloadBytes = 0;
+let downloadPackets = 0;
+let downloadActive = false;
+
+function parseArgs(argv) {
+  const out = { port: 5201, datagram: 1200, ipv6: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "-p" || a === "--port") out.port = parseInt(argv[++i], 10);
+    else if (a === "-6" || a === "--ipv6") out.ipv6 = true;
+    else if (a === "--datagram") out.datagram = parseInt(argv[++i], 10);
+    else if (a === "-h" || a === "--help") out.help = true;
+  }
+  return out;
+}
+
+if (args.help) {
+  console.log("LibreSpeed UDP server\n\n  node udp-server.js [-p <port>] [-6] [--datagram <bytes>]");
+  process.exit(0);
+}
+
+function send(pkt, rinfo) {
+  sock.send(pkt, rinfo.port, rinfo.address, function(err) {
+    if (err) console.error("send error:", err.message);
+  });
+}
+
+function sendReport(rinfo, kind, bytes, packets) {
+  const report = JSON.stringify({ kind: kind, bytes: bytes, packets: packets });
+  send(P.encode(P.TYPE_REPORT, 0, Date.now(), report), rinfo);
+}
+
+// Flood download datagrams to the client for `durationMs`, then report the count.
+async function startDownload(rinfo, durationMs) {
+  if (downloadActive) return;
+  downloadActive = true;
+  downloadBytes = 0;
+  downloadPackets = 0;
+
+  const payload = Buffer.alloc(DATAGRAM, 0xab);
+  const endAt = Date.now() + durationMs;
+  let seq = 0;
+
+  while (Date.now() < endAt) {
+    for (let i = 0; i < 500; i++) {
+      const pkt = P.encode(P.TYPE_DOWNLOAD, seq++, Date.now(), payload);
+      send(pkt, rinfo);
+      downloadBytes += pkt.length;
+      downloadPackets++;
+    }
+    // yield to the event loop so the socket stays responsive
+    await new Promise(function(resolve) { setImmediate(resolve); });
+  }
+
+  // Send the report a few times: a single UDP report could be lost.
+  for (let i = 0; i < 3; i++) {
+    sendReport(rinfo, "download", downloadBytes, downloadPackets);
+    await new Promise(function(resolve) { setTimeout(resolve, 100); });
+  }
+  downloadActive = false;
+}
+
+sock.on("message", function(msg, rinfo) {
+  const p = P.decode(msg);
+  if (!p) return;
+
+  switch (p.type) {
+    case P.TYPE_PING:
+      // echo back with the same seq + client timestamp
+      send(P.encode(P.TYPE_PING_ECHO, p.seq, p.timestamp), rinfo);
+      break;
+
+    case P.TYPE_UPLOAD:
+      uploadBytes += msg.length;
+      uploadPackets++;
+      break;
+
+    case P.TYPE_START_DL: {
+      const durationMs = p.payload && p.payload.length >= 4 ? p.payload.readUInt32BE(0) : 5000;
+      startDownload(rinfo, Math.min(durationMs, 60000)); // cap at 60s
+      break;
+    }
+
+    case P.TYPE_END: {
+      // upload test over: report received counters (3x for reliability), then reset
+      const bytes = uploadBytes;
+      const packets = uploadPackets;
+      uploadBytes = 0;
+      uploadPackets = 0;
+      for (let i = 0; i < 3; i++) {
+        setTimeout(function() { sendReport(rinfo, "upload", bytes, packets); }, i * 100);
+      }
+      break;
+    }
+  }
+});
+
+sock.on("error", function(err) {
+  console.error("server error:", err.message);
+  process.exit(1);
+});
+
+sock.on("listening", function() {
+  const addr = sock.address();
+  console.log("LibreSpeed UDP server listening on udp://" + addr.address + ":" + addr.port);
+  console.log("datagram payload: " + DATAGRAM + " bytes (" + (DATAGRAM + P.HEADER_SIZE) + " bytes on the wire)");
+});
+
+sock.bind(PORT, HOST);


### PR DESCRIPTION
﻿## Summary

Simulates real-world public-network transfer on top of LibreSpeed's existing XHR-based test, without changing the protocol stack (pure browser + an optional `Timing-Allow-Origin` header). Also adds a raw-UDP test for the UDP path that browsers cannot cover.

## What changed

### Transport overhead & connection setup (browser)

- **Real transport overhead instead of a fixed 1.06 factor**: the reported line rate is now derived from an Ethernet + IP + TCP + TLS + reverse-ACK model (`overhead_auto`). The worker separately reports:
  - payload throughput (`dlPayloadStatus` / `ulPayloadStatus`)
  - estimated line rate (`dlStatus` / `ulStatus`)
  - overhead percentage (`dlOverheadPct` / `ulOverheadPct`)
- **Connection setup cost**: TCP handshake, TLS handshake, TTFB and negotiated protocol (http/1.1 / h2 / h3) via Performance Resource Timing (`tcpHandshakeMs`, `tlsHandshakeMs`, `ttfbMs`, `nextHopProtocol`).
- **Slow-start curve**: download/upload throughput sampled every ~200 ms (`dlCurve` / `ulCurve`), rendered as a chart in both the classic and modern UI.
- **Backend**: `Timing-Allow-Origin: *` on `garbage.php` / `empty.php` / `getIP.php` so cross-origin (multiple points of test) timings are exposed.
- **Docs**: new settings and metrics documented in `doc.md`; new defaults in `settings.json`.

### Raw UDP test (`udp/`)

- Self-contained, zero-dependency Node.js UDP test (mini-iperf3 style):
  - `udp/udp-server.js` — raw UDP server (echo ping, count upload, flood download)
  - `udp/udp-client.js` — CLI client measuring ping/jitter/loss plus upload/download throughput
  - `udp/protocol.js` — shared 13-byte datagram header (type + seq + timestamp)
  - `udp/README.md` — usage and options
- Browsers cannot open raw UDP sockets, so this runs as a Node.js pair rather than in `speedtest_worker.js`. A browser-native UDP path would need WebTransport over HTTP/3 (QUIC) and is intentionally out of scope here.

## Notes

- Verified locally: UDP upload/download ~250-300 Mbps with 0% loss on loopback; ping/jitter/loss report correct packet accounting.
