### PR TITLE
fix: constrain shared result image on mobile

### DIFF
--- a/frontend/styling/dialog.css
+++ b/frontend/styling/dialog.css
@@ -32,6 +32,13 @@ dialog {
     animation: fade-in 0.3s ease-out;
   }
 
+  & > #results {
+    max-width: 100%;
+    max-height: calc(100% - 8rem);
+    height: auto;
+    object-fit: contain;
+  }
+
   & > .close-dialog {
     display: flex;
     align-items: center;

--- a/tests/e2e/mobile-result-image.spec.js
+++ b/tests/e2e/mobile-result-image.spec.js
@@ -3,31 +3,43 @@ const { baseUrls } = require("./helpers/env");
 
 test.use({ viewport: { width: 360, height: 800 } });
 
-test.describe("Mobile result-image sharing", () => {
-  test("keeps the result image within the share dialog", async ({ page }) => {
-    await page.goto(`${baseUrls.standaloneNew}/index-modern.html`);
+async function openResultImage(page, width, height) {
+  await page.goto(`${baseUrls.standaloneNew}/index-modern.html`);
 
-    await page.locator("#results").evaluate(image => {
+  await page.locator("#results").evaluate(
+    (image, dimensions) => {
       image.src =
         "data:image/svg+xml," +
         encodeURIComponent(
-          '<svg xmlns="http://www.w3.org/2000/svg" width="480" height="1600"><rect width="480" height="1600" fill="black"/></svg>'
+          `<svg xmlns="http://www.w3.org/2000/svg" width="${dimensions.width}" height="${dimensions.height}"><rect width="100%" height="100%" fill="black"/></svg>`
         );
-    });
-    await page.locator("#share").evaluate(dialog => dialog.showModal());
+    },
+    { width, height }
+  );
+  await page.locator("#share").evaluate(dialog => dialog.showModal());
 
-    const image = page.locator("#results");
-    await expect(image).toBeVisible();
-    await expect(image).toHaveJSProperty("complete", true);
+  const image = page.locator("#results");
+  await expect(image).toBeVisible();
+  await expect(image).toHaveJSProperty("complete", true);
 
-    const dimensions = await image.evaluate(element => ({
-      width: element.getBoundingClientRect().width,
-      height: element.getBoundingClientRect().height,
-      dialogWidth: element.closest("dialog").clientWidth,
-      dialogHeight: element.closest("dialog").clientHeight
-    }));
+  return image.evaluate(element => ({
+    width: element.getBoundingClientRect().width,
+    height: element.getBoundingClientRect().height,
+    dialogWidth: element.closest("dialog").clientWidth,
+    dialogHeight: element.closest("dialog").clientHeight
+  }));
+}
+
+test.describe("Mobile result-image sharing", () => {
+  test("keeps the landscape result image within the share dialog width", async ({ page }) => {
+    const dimensions = await openResultImage(page, 800, 480);
 
     expect(dimensions.width).toBeLessThanOrEqual(dimensions.dialogWidth);
+  });
+
+  test("keeps a tall result image within the share dialog height", async ({ page }) => {
+    const dimensions = await openResultImage(page, 480, 1600);
+
     expect(dimensions.height).toBeLessThanOrEqual(dimensions.dialogHeight);
   });
 });

--- a/tests/e2e/mobile-result-image.spec.js
+++ b/tests/e2e/mobile-result-image.spec.js
@@ -1,0 +1,30 @@
+const { test, expect } = require("@playwright/test");
+const { baseUrls } = require("./helpers/env");
+
+test.use({ viewport: { width: 360, height: 800 } });
+
+test.describe("Mobile result-image sharing", () => {
+  test("keeps the result image within the share dialog", async ({ page }) => {
+    await page.goto(`${baseUrls.standaloneNew}/index-modern.html`);
+
+    await page.locator("#results").evaluate(image => {
+      image.src =
+        "data:image/svg+xml," +
+        encodeURIComponent(
+          '<svg xmlns="http://www.w3.org/2000/svg" width="800" height="480"><rect width="800" height="480" fill="black"/></svg>'
+        );
+    });
+    await page.locator("#share").evaluate(dialog => dialog.showModal());
+
+    const image = page.locator("#results");
+    await expect(image).toBeVisible();
+    await expect(image).toHaveJSProperty("complete", true);
+
+    const dimensions = await image.evaluate(element => ({
+      width: element.getBoundingClientRect().width,
+      dialogWidth: element.closest("dialog").clientWidth
+    }));
+
+    expect(dimensions.width).toBeLessThanOrEqual(dimensions.dialogWidth);
+  });
+});

--- a/tests/e2e/mobile-result-image.spec.js
+++ b/tests/e2e/mobile-result-image.spec.js
@@ -11,7 +11,7 @@ test.describe("Mobile result-image sharing", () => {
       image.src =
         "data:image/svg+xml," +
         encodeURIComponent(
-          '<svg xmlns="http://www.w3.org/2000/svg" width="800" height="480"><rect width="800" height="480" fill="black"/></svg>'
+          '<svg xmlns="http://www.w3.org/2000/svg" width="480" height="1600"><rect width="480" height="1600" fill="black"/></svg>'
         );
     });
     await page.locator("#share").evaluate(dialog => dialog.showModal());
@@ -22,9 +22,12 @@ test.describe("Mobile result-image sharing", () => {
 
     const dimensions = await image.evaluate(element => ({
       width: element.getBoundingClientRect().width,
-      dialogWidth: element.closest("dialog").clientWidth
+      height: element.getBoundingClientRect().height,
+      dialogWidth: element.closest("dialog").clientWidth,
+      dialogHeight: element.closest("dialog").clientHeight
     }));
 
     expect(dimensions.width).toBeLessThanOrEqual(dimensions.dialogWidth);
+    expect(dimensions.height).toBeLessThanOrEqual(dimensions.dialogHeight);
   });
 });


### PR DESCRIPTION
## Summary

- scale the shared modern result image to the available dialog width and height
- add a 360 px viewport E2E regression test

## Verification

- `npm run test:e2e` — 19 passed
- `npx prettier --check frontend/styling/dialog.css tests/e2e/mobile-result-image.spec.js`
- `git diff --check`

Fixes the horizontal clipping visible when opening a shared result on mobile devices.